### PR TITLE
Expand brm_data class

### DIFF
--- a/R/brm_data.R
+++ b/R/brm_data.R
@@ -59,8 +59,8 @@
 #'   group = "col_group",
 #'   time = "col_time",
 #'   patient = "col_patient",
-#'   level_control = "group 1",
-#'   level_baseline = "time 1"
+#'   level_control = "group_1",
+#'   level_baseline = "time_1"
 #' )
 brm_data <- function(
   data,

--- a/R/brm_data.R
+++ b/R/brm_data.R
@@ -31,13 +31,22 @@
 #' @param group Character of length 1, name of the treatment group variable.
 #'   Must point to a character vector in the data. Factors are converted
 #'   to characters.
-#' @param base Character of length 1, name of the baseline response variable.
+#' @param baseline Character of length 1,
+#'   name of the baseline response variable.
 #'   Supply `NULL` to ignore or omit.
 #' @param time Character of length 1, name of the discrete time variable.
 #'   Must point to a character vector in the data. Factors are converted
 #'   to characters.
 #' @param patient Character of length 1, name of the patient ID variable.
 #' @param covariates Character vector of names of other covariates.
+#' @param missing Character of length 1, name of an optional variable
+#'   in a simulated dataset to indicate which outcome values should be missing.
+#'   Set to `NULL` to omit.
+#' @param level_baseline Character of length 1, Level of the `time` column
+#'   to indicate the baseline time point. Expected if `role` is `"change"`.
+#'   Set to `NULL` to omit.
+#' @param level_control Character of length 1, Level of the `group` column
+#'   to indicate the control group.
 #' @examples
 #' set.seed(0)
 #' data <- brm_simulate_simple()$data
@@ -49,28 +58,36 @@
 #'   role = "response",
 #'   group = "col_group",
 #'   time = "col_time",
-#'   patient = "col_patient"
+#'   patient = "col_patient",
+#'   level_control = "group 1",
+#'   level_baseline = "time 1"
 #' )
 brm_data <- function(
   data,
   outcome = "CHG",
   role = "change",
-  base = NULL,
+  baseline = NULL,
   group = "TRT01P",
   time = "AVISIT",
   patient = "USUBJID",
-  covariates = character(0)
+  covariates = character(0L),
+  missing = NULL,
+  level_control = "Placebo",
+  level_baseline = NULL
 ) {
   assert(is.data.frame(data), message = "data arg must be a data frame.")
   out <- brm_data_new(
     data = data,
     brm_outcome = as.character(outcome),
     brm_role = as.character(role),
-    brm_base = base,
+    brm_baseline = baseline,
     brm_group = as.character(group),
     brm_time = as.character(time),
     brm_patient = as.character(patient),
-    brm_covariates = as.character(covariates)
+    brm_covariates = as.character(covariates),
+    brm_missing = missing,
+    brm_level_control = as.character(level_control),
+    brm_level_baseline = level_baseline
   )
   brm_data_validate(data = out)
   brm_data_preprocess(out)
@@ -80,11 +97,14 @@ brm_data_new <- function(
   data,
   brm_outcome,
   brm_role,
-  brm_base = NULL,
+  brm_baseline = NULL,
   brm_group,
   brm_time,
   brm_patient,
   brm_covariates,
+  brm_missing = NULL,
+  brm_level_control,
+  brm_level_baseline = NULL,
   brm_levels_group = NULL,
   brm_levels_time = NULL,
   brm_labels_group = NULL,
@@ -95,11 +115,14 @@ brm_data_new <- function(
     out,
     brm_outcome = brm_outcome,
     brm_role = brm_role,
-    brm_base = brm_base,
+    brm_baseline = brm_baseline,
     brm_group = brm_group,
     brm_time = brm_time,
     brm_patient = brm_patient,
     brm_covariates = brm_covariates,
+    brm_missing = brm_missing,
+    brm_level_control = brm_level_control,
+    brm_level_baseline = brm_level_baseline,
     brm_levels_group = brm_levels_group,
     brm_levels_time = brm_levels_time,
     brm_labels_group = brm_labels_group,
@@ -117,46 +140,64 @@ brm_data_preprocess <- function(out) {
 brm_data_validate <- function(data) {
   outcome <- attr(data, "brm_outcome")
   role <- attr(data, "brm_role")
-  base <- attr(data, "brm_base")
+  baseline <- attr(data, "brm_baseline")
   group <- attr(data, "brm_group")
   time <- attr(data, "brm_time")
   patient <- attr(data, "brm_patient")
   covariates <- attr(data, "brm_covariates")
   levels_group <- attr(data, "brm_levels_group")
   levels_time <- attr(data, "brm_levels_time")
+  missing <- attr(data, "brm_missing")
+  level_control <- attr(data, "brm_level_control")
+  level_baseline <- attr(data, "brm_level_baseline")
   assert(is.data.frame(data), message = "data must be a data frame")
   assert(inherits(data, "brm_data"), message = "data not from brm_data()")
   assert_chr(outcome, "outcome of data must be a nonempty character string")
   assert_chr(role, "role of data must be a nonempty character string")
-  assert_chr(base %|||% "base", "base of data must NULL or character")
+  assert_chr(baseline %|||% "baseline", "baseline must NULL or character")
   assert_chr(group, "group of data must be a nonempty character string")
   assert_chr(time, "time of data must be a nonempty character string")
   assert_chr(patient, "patient of data must be a nonempty character string")
   assert_chr_vec(covariates, "covariates of data must be a character vector")
+  assert_chr(missing %|||% "missing", "missing must NULL or character")
+  assert_chr(level_control, "level_control must be a nonempty string")
+  assert_chr(level_baseline %|||% "b", "level_baseline must NULL or character")
   assert(
     role %in% c("response", "change"),
     message = "role must be either \"response\" or \"change\""
   )
   assert_col(outcome, data)
-  assert_col(base, data)
+  assert_col(baseline, data)
   assert_col(group, data)
   assert_col(time, data)
   assert_col(patient, data)
   assert_col(covariates, data)
+  assert_col(missing, data)
   assert_machine_names(outcome)
-  assert_machine_names(base %|||% "base")
+  assert_machine_names(baseline %|||% "baseline")
   assert_machine_names(group)
   assert_machine_names(time)
   assert_machine_names(patient)
   assert_machine_names(covariates)
+  assert_machine_names(missing)
   assert(
     all(levels_group %in% data[[group]]),
     message = "all group levels must be in data[[group]]"
   )
   assert(
+    level_control %in% data[[group]],
+    message = "level_control must be in data[[group]]"
+  )
+  assert(
     all(levels_time %in% data[[time]]),
     message = "all time levels must be in data[[time]]"
   )
+  if (!is.null(level_baseline)) {
+    assert(
+      all(level_baseline %in% data[[time]]),
+      message = "level_baseline must be in data[[time]]"
+    )
+  }
   sep <- brm_sep()
   elements <- c(group, time, unique(data[[group]]), unique(data[[time]]))
   assert(
@@ -175,7 +216,7 @@ brm_data_validate <- function(data) {
     is.numeric(data[[outcome]]),
     message = "outcome variable in the data must be numeric."
   )
-  for (column in c(base, group, time, patient, covariates)) {
+  for (column in c(baseline, group, time, patient, covariates)) {
     assert(
       !anyNA(data[[column]]),
       message = sprintf(
@@ -193,16 +234,28 @@ brm_data_validate <- function(data) {
       )
     )
   }
+  if (role == "response") {
+    assert(
+      !is.null(level_baseline),
+      message = "level_baseline is needed if role is \"response\"."
+    )
+  } else if (role == "change") {
+    assert(
+      is.null(level_baseline),
+      message = "level_baseline should be NULL if role is \"change\"."
+    )
+  }
 }
 
 brm_data_select <- function(data) {
   columns <- c(
     attr(data, "brm_outcome"),
-    attr(data, "brm_base"),
+    attr(data, "brm_baseline"),
     attr(data, "brm_group"),
     attr(data, "brm_time"),
     attr(data, "brm_patient"),
-    attr(data, "brm_covariates")
+    attr(data, "brm_covariates"),
+    attr(data, "brm_missing")
   )
   columns <- as.character(columns)
   data[, columns, drop = FALSE]
@@ -211,6 +264,8 @@ brm_data_select <- function(data) {
 brm_data_level <- function(data) {
   group <- attr(data, "brm_group")
   time <- attr(data, "brm_time")
+  level_control <- attr(data, "brm_level_control")
+  level_baseline <- attr(data, "brm_level_baseline")
   names_group <- brm_levels(data[[group]])
   names_time <- brm_levels(data[[time]])
   all_group <- tibble::tibble(label = data[[group]], level = names_group)
@@ -219,6 +274,10 @@ brm_data_level <- function(data) {
   data[[time]] <- as.character(names_time)
   meta_group <- dplyr::arrange(dplyr::distinct(all_group), level)
   meta_time <- dplyr::arrange(dplyr::distinct(all_time), level)
+  attr(data, "brm_level_control") <- brm_levels(level_control)
+  if (!is.null(level_baseline)) {
+    attr(data, "brm_level_baseline") <- brm_levels(level_baseline)
+  }
   attr(data, "brm_levels_group") <- as.character(meta_group$level)
   attr(data, "brm_levels_time") <- as.character(meta_time$level)
   attr(data, "brm_labels_group") <- as.character(meta_group$label)
@@ -250,7 +309,7 @@ brm_chr_head_unique <- function(x, n = 30L) {
 
 brm_data_fill <- function(data) {
   attributes <- brm_data_attributes(data)
-  base <- attr(data, "brm_base")
+  baseline <- attr(data, "brm_baseline")
   group <- attr(data, "brm_group")
   time <- attr(data, "brm_time")
   patient <- attr(data, "brm_patient")
@@ -259,7 +318,7 @@ brm_data_fill <- function(data) {
   data <- do.call(what = tidyr::complete, args = args)
   args <- list(.data = data, as.symbol(patient), as.symbol(time))
   data <- do.call(what = dplyr::arrange, args = args)
-  for (column in c(base, group, covariates)) {
+  for (column in c(baseline, group, covariates)) {
     data[[column]] <- brm_data_fill_column(data[[column]], data[[patient]])
   }
   args <- list(

--- a/R/brm_formula.R
+++ b/R/brm_formula.R
@@ -79,7 +79,10 @@ brm_formula <- function(
     term("0", !intercept),
     term(time, effect_time),
     term(baseline, effect_baseline && !is.null(baseline)),
-    term(paste0(baseline, ":", time), interaction_baseline && !is.null(baseline)),
+    term(
+      paste0(baseline, ":", time),
+      interaction_baseline && !is.null(baseline)
+    ),
     term(group, effect_group),
     term(paste0(group, ":", time), interaction_group),
     covariates,

--- a/R/brm_formula.R
+++ b/R/brm_formula.R
@@ -9,13 +9,13 @@
 #' @param correlation Character of length 1, name of the correlation
 #'   structure. Only `"unstructured"` is currently supported.
 #' @param intercept `TRUE` to include an intercept, `FALSE` to omit.
-#' @param effect_base `TRUE` to include an additive effect for baseline
+#' @param effect_baseline `TRUE` to include an additive effect for baseline
 #'   response, `FALSE` to omit.
 #' @param effect_group `TRUE` to include an additive effects for treatment
 #'   groups, `FALSE` to omit.
 #' @param effect_time `TRUE` to include a additive effect for discrete
 #'   time points, `FALSE` to omit.
-#' @param interaction_base `TRUE` to include baseline-by-time interaction,
+#' @param interaction_baseline `TRUE` to include baseline-by-time interaction,
 #'   `FALSE` to omit.
 #' @param interaction_group `TRUE` to include treatment-group-by-time
 #'   interaction, `FALSE` to omit.
@@ -30,20 +30,20 @@
 #'   patient = "patient"
 #' )
 #' brm_formula(data)
-#' brm_formula(data = data, intercept = FALSE, effect_base = FALSE)
+#' brm_formula(data = data, intercept = FALSE, effect_baseline = FALSE)
 #' brm_formula(
 #'   data = data,
 #'   intercept = FALSE,
-#'   effect_base = FALSE,
+#'   effect_baseline = FALSE,
 #'   interaction_group = FALSE
 #' )
 brm_formula <- function(
   data,
   intercept = TRUE,
-  effect_base = TRUE,
+  effect_baseline = TRUE,
   effect_group = TRUE,
   effect_time = TRUE,
-  interaction_base = TRUE,
+  interaction_baseline = TRUE,
   interaction_group = TRUE,
   correlation = "unstructured"
 ) {
@@ -51,8 +51,8 @@ brm_formula <- function(
   assert_lgl(intercept)
   assert_lgl(effect_group)
   assert_lgl(effect_time)
-  assert_lgl(effect_base)
-  assert_lgl(interaction_base)
+  assert_lgl(effect_baseline)
+  assert_lgl(interaction_baseline)
   assert_lgl(interaction_group)
   assert_chr(
     correlation,
@@ -68,7 +68,7 @@ brm_formula <- function(
   )
   outcome <- attr(data, "brm_outcome")
   role <- attr(data, "brm_role")
-  base <- attr(data, "brm_base")
+  baseline <- attr(data, "brm_baseline")
   group <- attr(data, "brm_group")
   time <- attr(data, "brm_time")
   patient <- attr(data, "brm_patient")
@@ -76,8 +76,8 @@ brm_formula <- function(
   terms <- c(
     term("0", !intercept),
     term(time, effect_time),
-    term(base, effect_base && !is.null(base)),
-    term(paste0(base, ":", time), interaction_base && !is.null(base)),
+    term(baseline, effect_baseline && !is.null(baseline)),
+    term(paste0(baseline, ":", time), interaction_baseline && !is.null(baseline)),
     term(group, effect_group),
     term(paste0(group, ":", time), interaction_group),
     covariates,

--- a/R/brm_formula.R
+++ b/R/brm_formula.R
@@ -27,7 +27,9 @@
 #'   role = "response",
 #'   group = "group",
 #'   time = "time",
-#'   patient = "patient"
+#'   patient = "patient",
+#'   level_control = "group_1",
+#'   level_baseline = "time_1"
 #' )
 #' brm_formula(data)
 #' brm_formula(data = data, intercept = FALSE, effect_baseline = FALSE)

--- a/R/brm_marginal_data.R
+++ b/R/brm_marginal_data.R
@@ -32,7 +32,9 @@
 #'   role = "response",
 #'   group = "group",
 #'   time = "time",
-#'   patient = "patient"
+#'   patient = "patient",
+#'   level_control = "group 1",
+#'   level_baseline = "time 1"
 #' )
 #' brm_marginal_data(data = data)
 brm_marginal_data <- function(data, level = 0.95) {

--- a/R/brm_marginal_data.R
+++ b/R/brm_marginal_data.R
@@ -33,8 +33,8 @@
 #'   group = "group",
 #'   time = "time",
 #'   patient = "patient",
-#'   level_control = "group 1",
-#'   level_baseline = "time 1"
+#'   level_control = "group_1",
+#'   level_baseline = "time_1"
 #' )
 #' brm_marginal_data(data = data)
 brm_marginal_data <- function(data, level = 0.95) {

--- a/R/brm_marginal_draws.R
+++ b/R/brm_marginal_draws.R
@@ -29,13 +29,13 @@
 #'   group = "group",
 #'   time = "time",
 #'   patient = "patient",
-#'   level_control = "group 1",
-#'   level_baseline = "time 1"
+#'   level_control = "group_1",
+#'   level_baseline = "time_1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,
-#'   effect_base = FALSE,
-#'   interaction_base = FALSE
+#'   effect_baseline = FALSE,
+#'   interaction_baseline = FALSE
 #' )
 #' tmp <- utils::capture.output(
 #'   suppressMessages(

--- a/R/brm_marginal_draws.R
+++ b/R/brm_marginal_draws.R
@@ -17,17 +17,8 @@
 #'   group and discrete time point.
 #' @param model Fitted `brms` model object from [brm_model()].
 #' @param data Classed tibble with preprocessed data from [brm_data()].
-#' @param control Element of the `group` column in the data which indicates
-#'   the control group for the purposes of calculating treatment differences.
-#'   Elements in `data[[group]]` are already pre-processed by [brm_data()],
-#'   so `control` is automatically sanitized accordingly using
-#'   `make.names(control, unique = FALSE, allow_ = TRUE)`.
-#' @param baseline Element of the `time` column in the data
-#'   which indicates the baseline time for the purposes of calculating
-#'   change from baseline.
-#'   Elements in `data[[group]]` are already pre-processed by [brm_data()],
-#'   so `control` is automatically sanitized accordingly using
-#'   `make.names(control, unique = FALSE, allow_ = TRUE)`.
+#' @param control Deprecated. Set the control group level in [brm_data()].
+#' @param baseline Deprecated. Set the control group level in [brm_data()].
 #' @examples
 #' if (identical(Sys.getenv("BRM_EXAMPLES", unset = ""), "true")) {
 #' set.seed(0L)
@@ -37,7 +28,9 @@
 #'   role = "response",
 #'   group = "group",
 #'   time = "time",
-#'   patient = "patient"
+#'   patient = "patient",
+#'   level_control = "group 1",
+#'   level_baseline = "time 1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,
@@ -57,19 +50,26 @@
 #'     )
 #'   )
 #' )
-#' brm_marginal_draws(
-#'   model = model,
-#'   data = data,
-#'   control = "group 1",
-#'   baseline = "time 1"
-#' )
+#' brm_marginal_draws(model = model, data = data)
 #' }
 brm_marginal_draws <- function(
   model,
   data,
-  control = "Placebo",
-  baseline = "Baseline"
+  control = NULL,
+  baseline = NULL
 ) {
+  if (!is.null(control)) {
+    brm_deprecate(
+      "The control argument was deprecated on 2023-09-07. ",
+      "Set the level_control argument of brm_data() instead."
+    )
+  }
+  if (!is.null(baseline)) {
+    brm_deprecate(
+      "The baseline argument was deprecated on 2023-09-07. ",
+      "Set the level_baseline argument of brm_data() instead."
+    )
+  }
   brm_data_validate(data)
   role <- attr(data, "brm_role")
   base <- attr(data, "brm_base")
@@ -79,22 +79,8 @@ brm_marginal_draws <- function(
   covariates <- attr(data, "brm_covariates")
   levels_group <- attr(data, "brm_levels_group")
   levels_time <- attr(data, "brm_levels_time")
-  assert(
-    control,
-    is.atomic(.),
-    length(.) == 1L,
-    !anyNA(.),
-    message = "control arg must be a length-1 non-missing atomic value"
-  )
-  assert(
-    baseline,
-    is.atomic(.),
-    length(.) == 1L,
-    !anyNA(.),
-    message = "baseline arg must be a length-1 non-missing atomic value"
-  )
-  control <- brm_levels(control)
-  baseline <- brm_levels(baseline)
+  control <- attr(data, "brm_level_control")
+  baseline <- attr(data, "brm_level_baseline")
   assert(
     control %in% as.character(data[[group]]),
     message = "control arg must be a treatment group level in the data"

--- a/R/brm_marginal_draws_average.R
+++ b/R/brm_marginal_draws_average.R
@@ -36,7 +36,9 @@
 #'   role = "response",
 #'   group = "group",
 #'   time = "time",
-#'   patient = "patient"
+#'   patient = "patient",
+#'   level_control = "group 1",
+#'   level_baseline = "time 1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,
@@ -56,12 +58,7 @@
 #'     )
 #'   )
 #' )
-#' draws <- brm_marginal_draws(
-#'   model = model,
-#'   data = data,
-#'   control = "group 1",
-#'   baseline = "time 1"
-#' )
+#' draws <- brm_marginal_draws(model = model, data = data)
 #' brm_marginal_draws_average(draws = draws, data = data)
 #' brm_marginal_draws_average(
 #'   draws = draws,

--- a/R/brm_marginal_draws_average.R
+++ b/R/brm_marginal_draws_average.R
@@ -37,13 +37,13 @@
 #'   group = "group",
 #'   time = "time",
 #'   patient = "patient",
-#'   level_control = "group 1",
-#'   level_baseline = "time 1"
+#'   level_control = "group_1",
+#'   level_baseline = "time_1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,
-#'   effect_base = FALSE,
-#'   interaction_base = FALSE
+#'   effect_baseline = FALSE,
+#'   interaction_baseline = FALSE
 #' )
 #' tmp <- utils::capture.output(
 #'   suppressMessages(
@@ -63,7 +63,7 @@
 #' brm_marginal_draws_average(
 #'   draws = draws,
 #'   data = data,
-#'   times = c("time 1", "time 2"),
+#'   times = c("time_1", "time_2"),
 #'   label = "mean"
 #' )
 #' }

--- a/R/brm_marginal_probabilities.R
+++ b/R/brm_marginal_probabilities.R
@@ -34,13 +34,13 @@
 #'   group = "group",
 #'   time = "time",
 #'   patient = "patient",
-#'   level_control = "group 1",
-#'   level_baseline = "time 1"
+#'   level_control = "group_1",
+#'   level_baseline = "time_1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,
-#'   effect_base = FALSE,
-#'   interaction_base = FALSE
+#'   effect_baseline = FALSE,
+#'   interaction_baseline = FALSE
 #' )
 #' tmp <- utils::capture.output(
 #'   suppressMessages(

--- a/R/brm_marginal_probabilities.R
+++ b/R/brm_marginal_probabilities.R
@@ -33,7 +33,9 @@
 #'   role = "response",
 #'   group = "group",
 #'   time = "time",
-#'   patient = "patient"
+#'   patient = "patient",
+#'   level_control = "group 1",
+#'   level_baseline = "time 1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,
@@ -53,12 +55,7 @@
 #'     )
 #'   )
 #' )
-#' draws <- brm_marginal_draws(
-#'   model = model,
-#'   data = data,
-#'   control = "group 1",
-#'   baseline = "time 1"
-#' )
+#' draws <- brm_marginal_draws(model = model, data = data)
 #' brm_marginal_probabilities(draws, direction = "greater", threshold = 0)
 #' }
 brm_marginal_probabilities <- function(

--- a/R/brm_marginal_summaries.R
+++ b/R/brm_marginal_summaries.R
@@ -39,13 +39,13 @@
 #'   group = "group",
 #'   time = "time",
 #'   patient = "patient",
-#'   level_control = "group 1",
-#'   level_baseline = "time 1"
+#'   level_control = "group_1",
+#'   level_baseline = "time_1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,
-#'   effect_base = FALSE,
-#'   interaction_base = FALSE
+#'   effect_baseline = FALSE,
+#'   interaction_baseline = FALSE
 #' )
 #' tmp <- utils::capture.output(
 #'   suppressMessages(

--- a/R/brm_marginal_summaries.R
+++ b/R/brm_marginal_summaries.R
@@ -38,7 +38,9 @@
 #'   role = "response",
 #'   group = "group",
 #'   time = "time",
-#'   patient = "patient"
+#'   patient = "patient",
+#'   level_control = "group 1",
+#'   level_baseline = "time 1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,
@@ -58,12 +60,7 @@
 #'     )
 #'   )
 #' )
-#' draws <- brm_marginal_draws(
-#'   model = model,
-#'   data = data,
-#'   control = "group 1",
-#'   baseline = "time 1"
-#' )
+#' draws <- brm_marginal_draws(model = model, data = data)
 #' suppressWarnings(brm_marginal_summaries(draws))
 #' }
 brm_marginal_summaries <- function(

--- a/R/brm_model.R
+++ b/R/brm_model.R
@@ -23,7 +23,9 @@
 #'   role = "response",
 #'   group = "group",
 #'   time = "time",
-#'   patient = "patient"
+#'   patient = "patient",
+#'   level_control = "group 1",
+#'   level_baseline = "time 1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,

--- a/R/brm_model.R
+++ b/R/brm_model.R
@@ -24,13 +24,13 @@
 #'   group = "group",
 #'   time = "time",
 #'   patient = "patient",
-#'   level_control = "group 1",
-#'   level_baseline = "time 1"
+#'   level_control = "group_1",
+#'   level_baseline = "time_1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,
-#'   effect_base = FALSE,
-#'   interaction_base = FALSE
+#'   effect_baseline = FALSE,
+#'   interaction_baseline = FALSE
 #' )
 #' tmp <- utils::capture.output(
 #'   suppressMessages(

--- a/R/brm_plot_compare.R
+++ b/R/brm_plot_compare.R
@@ -19,8 +19,8 @@
 #'   group = "group",
 #'   time = "time",
 #'   patient = "patient",
-#'   level_control = "group 1",
-#'   level_baseline = "time 1"
+#'   level_control = "group_1",
+#'   level_baseline = "time_1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,

--- a/R/brm_plot_compare.R
+++ b/R/brm_plot_compare.R
@@ -18,11 +18,13 @@
 #'   role = "response",
 #'   group = "group",
 #'   time = "time",
-#'   patient = "patient"
+#'   patient = "patient",
+#'   level_control = "group 1",
+#'   level_baseline = "time 1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,
-#'   effect_base = FALSE,
+#'   effect_baseline = FALSE,
 #'   interaction_base = FALSE
 #' )
 #' tmp <- utils::capture.output(
@@ -38,12 +40,7 @@
 #'     )
 #'   )
 #' )
-#' draws <- brm_marginal_draws(
-#'   model = model,
-#'   data = data,
-#'   control = "group 1",
-#'   baseline = "time 1"
-#' )
+#' draws <- brm_marginal_draws(model = model, data = data)
 #' suppressWarnings(summaries_draws <- brm_marginal_summaries(draws))
 #' summaries_data <- brm_marginal_data(data)
 #' brm_plot_compare(

--- a/R/brm_plot_draws.R
+++ b/R/brm_plot_draws.R
@@ -14,11 +14,13 @@
 #'   role = "response",
 #'   group = "group",
 #'   time = "time",
-#'   patient = "patient"
+#'   patient = "patient",
+#'   level_control = "group 1",
+#'   level_baseline = "time 1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,
-#'   effect_base = FALSE,
+#'   effect_baseline = FALSE,
 #'   interaction_base = FALSE
 #' )
 #' tmp <- utils::capture.output(
@@ -34,12 +36,7 @@
 #'     )
 #'   )
 #' )
-#' draws <- brm_marginal_draws(
-#'   model = model,
-#'   data = data,
-#'   control = "group 1",
-#'   baseline = "time 1"
-#' )
+#' draws <- brm_marginal_draws(model = model, data = data)
 #' brm_plot_draws(draws = draws$change)
 #' }
 brm_plot_draws <- function(draws) {

--- a/R/brm_plot_draws.R
+++ b/R/brm_plot_draws.R
@@ -15,8 +15,8 @@
 #'   group = "group",
 #'   time = "time",
 #'   patient = "patient",
-#'   level_control = "group 1",
-#'   level_baseline = "time 1"
+#'   level_control = "group_1",
+#'   level_baseline = "time_1"
 #' )
 #' formula <- brm_formula(
 #'   data = data,

--- a/R/brm_simulate_outline.R
+++ b/R/brm_simulate_outline.R
@@ -48,8 +48,8 @@ brm_simulate_outline <- function(
     patient = "patient",
     covariates = character(0L),
     missing = "missing",
-    level_control = "group 1",
-    level_baseline = "time 1"
+    level_control = "group_1",
+    level_baseline = "time_1"
   )
   brm_data_validate(data)
   data

--- a/R/brm_simulate_outline.R
+++ b/R/brm_simulate_outline.R
@@ -119,7 +119,7 @@ brm_simulate_lapse <- function(data, rate) {
 
 brm_simulate_levels <- function(data) {
   for (field in c("group", "patient", "time")) {
-    data[[field]] <- paste(field, data[[field]])
+    data[[field]] <- paste0(field, "_", data[[field]])
   }
   data
 }

--- a/R/brm_simulate_outline.R
+++ b/R/brm_simulate_outline.R
@@ -38,19 +38,20 @@ brm_simulate_outline <- function(
   data <- brm_simulate_lapse(data = data, rate = rate_lapse)
   data <- brm_simulate_levels(data = data)
   data$response <- NA_real_
-  # nolint start
-  # data <- brm_data(
-  #   data = data,
-  #   outcome = "response",
-  #   role = "response",
-  #   base = NULL,
-  #   group = "group",
-  #   time = "time",
-  #   patient = "patient",
-  #   covariates = character(0L)
-  # )
-  # brm_data_validate(data)
-  # nolint end
+  data <- brm_data(
+    data = data,
+    outcome = "response",
+    role = "response",
+    baseline = NULL,
+    group = "group",
+    time = "time",
+    patient = "patient",
+    covariates = character(0L),
+    missing = "missing",
+    level_control = "group 1",
+    level_baseline = "time 1"
+  )
+  brm_data_validate(data)
   data
 }
 

--- a/R/brm_simulate_simple.R
+++ b/R/brm_simulate_simple.R
@@ -63,10 +63,10 @@ brm_simulate_simple <- function(
   assert_pos(hyper_tau, message = "hyper_tau must be 1 positive number")
   assert_pos(hyper_lambda, message = "hyper_lambda must be 1 positive number")
   patients <- tibble::tibble(
-    group = paste("group", rep(seq_len(n_group), each = n_patient)),
-    patient = paste("patient", seq_len(n_group * n_patient))
+    group = paste0("group_", rep(seq_len(n_group), each = n_patient)),
+    patient = paste0("patient_", seq_len(n_group * n_patient))
   )
-  levels_time <- paste("time", seq_len(n_time))
+  levels_time <- paste0("time_", seq_len(n_time))
   grid <- tidyr::expand_grid(patients, time = levels_time)
   model_matrix <- model.matrix(~ 0 + group + time, data = grid)
   beta <- stats::rnorm(n = ncol(model_matrix), mean = 0, sd = hyper_beta)
@@ -83,6 +83,19 @@ brm_simulate_simple <- function(
     Sigma = covariance
   )
   data <- tibble::tibble(response = do.call(what = c, args = response), grid)
+  data <- brm_data(
+    data = data,
+    outcome = "response",
+    role = "response",
+    baseline = NULL,
+    group = "group",
+    time = "time",
+    patient = "patient",
+    covariates = character(0L),
+    missing = NULL,
+    level_control = "group_1",
+    level_baseline = "time_1"
+  )
   parameters <- list(
     beta = beta,
     tau = tau,

--- a/man/brm_data.Rd
+++ b/man/brm_data.Rd
@@ -8,11 +8,14 @@ brm_data(
   data,
   outcome = "CHG",
   role = "change",
-  base = NULL,
+  baseline = NULL,
   group = "TRT01P",
   time = "AVISIT",
   patient = "USUBJID",
-  covariates = character(0)
+  covariates = character(0L),
+  missing = NULL,
+  level_control = "Placebo",
+  level_baseline = NULL
 )
 }
 \arguments{
@@ -24,7 +27,8 @@ brm_data(
 is the raw response variable (e.g. AVAL) or \code{"change"} if \code{outcome}
 is change from baseline (e.g. CHG).}
 
-\item{base}{Character of length 1, name of the baseline response variable.
+\item{baseline}{Character of length 1,
+name of the baseline response variable.
 Supply \code{NULL} to ignore or omit.}
 
 \item{group}{Character of length 1, name of the treatment group variable.
@@ -38,6 +42,17 @@ to characters.}
 \item{patient}{Character of length 1, name of the patient ID variable.}
 
 \item{covariates}{Character vector of names of other covariates.}
+
+\item{missing}{Character of length 1, name of an optional variable
+in a simulated dataset to indicate which outcome values should be missing.
+Set to \code{NULL} to omit.}
+
+\item{level_control}{Character of length 1, Level of the \code{group} column
+to indicate the control group.}
+
+\item{level_baseline}{Character of length 1, Level of the \code{time} column
+to indicate the baseline time point. Expected if \code{role} is \code{"change"}.
+Set to \code{NULL} to omit.}
 }
 \value{
 A classed tibble with attributes which denote features of
@@ -84,7 +99,9 @@ brm_data(
   role = "response",
   group = "col_group",
   time = "col_time",
-  patient = "col_patient"
+  patient = "col_patient",
+  level_control = "group 1",
+  level_baseline = "time 1"
 )
 }
 \concept{data}

--- a/man/brm_data.Rd
+++ b/man/brm_data.Rd
@@ -100,8 +100,8 @@ brm_data(
   group = "col_group",
   time = "col_time",
   patient = "col_patient",
-  level_control = "group 1",
-  level_baseline = "time 1"
+  level_control = "group_1",
+  level_baseline = "time_1"
 )
 }
 \concept{data}

--- a/man/brm_formula.Rd
+++ b/man/brm_formula.Rd
@@ -7,10 +7,10 @@
 brm_formula(
   data,
   intercept = TRUE,
-  effect_base = TRUE,
+  effect_baseline = TRUE,
   effect_group = TRUE,
   effect_time = TRUE,
-  interaction_base = TRUE,
+  interaction_baseline = TRUE,
   interaction_group = TRUE,
   correlation = "unstructured"
 )
@@ -20,7 +20,7 @@ brm_formula(
 
 \item{intercept}{\code{TRUE} to include an intercept, \code{FALSE} to omit.}
 
-\item{effect_base}{\code{TRUE} to include an additive effect for baseline
+\item{effect_baseline}{\code{TRUE} to include an additive effect for baseline
 response, \code{FALSE} to omit.}
 
 \item{effect_group}{\code{TRUE} to include an additive effects for treatment
@@ -29,7 +29,7 @@ groups, \code{FALSE} to omit.}
 \item{effect_time}{\code{TRUE} to include a additive effect for discrete
 time points, \code{FALSE} to omit.}
 
-\item{interaction_base}{\code{TRUE} to include baseline-by-time interaction,
+\item{interaction_baseline}{\code{TRUE} to include baseline-by-time interaction,
 \code{FALSE} to omit.}
 
 \item{interaction_group}{\code{TRUE} to include treatment-group-by-time
@@ -57,11 +57,11 @@ data <- brm_data(
   patient = "patient"
 )
 brm_formula(data)
-brm_formula(data = data, intercept = FALSE, effect_base = FALSE)
+brm_formula(data = data, intercept = FALSE, effect_baseline = FALSE)
 brm_formula(
   data = data,
   intercept = FALSE,
-  effect_base = FALSE,
+  effect_baseline = FALSE,
   interaction_group = FALSE
 )
 }

--- a/man/brm_formula.Rd
+++ b/man/brm_formula.Rd
@@ -54,7 +54,9 @@ data <- brm_data(
   role = "response",
   group = "group",
   time = "time",
-  patient = "patient"
+  patient = "patient",
+  level_control = "group_1",
+  level_baseline = "time_1"
 )
 brm_formula(data)
 brm_formula(data = data, intercept = FALSE, effect_baseline = FALSE)

--- a/man/brm_marginal_data.Rd
+++ b/man/brm_marginal_data.Rd
@@ -46,8 +46,8 @@ data <- brm_data(
   group = "group",
   time = "time",
   patient = "patient",
-  level_control = "group 1",
-  level_baseline = "time 1"
+  level_control = "group_1",
+  level_baseline = "time_1"
 )
 brm_marginal_data(data = data)
 }

--- a/man/brm_marginal_data.Rd
+++ b/man/brm_marginal_data.Rd
@@ -45,7 +45,9 @@ data <- brm_data(
   role = "response",
   group = "group",
   time = "time",
-  patient = "patient"
+  patient = "patient",
+  level_control = "group 1",
+  level_baseline = "time 1"
 )
 brm_marginal_data(data = data)
 }

--- a/man/brm_marginal_draws.Rd
+++ b/man/brm_marginal_draws.Rd
@@ -4,25 +4,16 @@
 \alias{brm_marginal_draws}
 \title{MCMC draws from the marginal posterior of an MMRM}
 \usage{
-brm_marginal_draws(model, data, control = "Placebo", baseline = "Baseline")
+brm_marginal_draws(model, data, control = NULL, baseline = NULL)
 }
 \arguments{
 \item{model}{Fitted \code{brms} model object from \code{\link[=brm_model]{brm_model()}}.}
 
 \item{data}{Classed tibble with preprocessed data from \code{\link[=brm_data]{brm_data()}}.}
 
-\item{control}{Element of the \code{group} column in the data which indicates
-the control group for the purposes of calculating treatment differences.
-Elements in \code{data[[group]]} are already pre-processed by \code{\link[=brm_data]{brm_data()}},
-so \code{control} is automatically sanitized accordingly using
-\code{make.names(control, unique = FALSE, allow_ = TRUE)}.}
+\item{control}{Deprecated. Set the control group level in \code{\link[=brm_data]{brm_data()}}.}
 
-\item{baseline}{Element of the \code{time} column in the data
-which indicates the baseline time for the purposes of calculating
-change from baseline.
-Elements in \code{data[[group]]} are already pre-processed by \code{\link[=brm_data]{brm_data()}},
-so \code{control} is automatically sanitized accordingly using
-\code{make.names(control, unique = FALSE, allow_ = TRUE)}.}
+\item{baseline}{Deprecated. Set the control group level in \code{\link[=brm_data]{brm_data()}}.}
 }
 \value{
 A named list of tibbles of MCMC draws of the marginal posterior
@@ -62,7 +53,9 @@ data <- brm_data(
   role = "response",
   group = "group",
   time = "time",
-  patient = "patient"
+  patient = "patient",
+  level_control = "group 1",
+  level_baseline = "time 1"
 )
 formula <- brm_formula(
   data = data,
@@ -82,12 +75,7 @@ tmp <- utils::capture.output(
     )
   )
 )
-brm_marginal_draws(
-  model = model,
-  data = data,
-  control = "group 1",
-  baseline = "time 1"
-)
+brm_marginal_draws(model = model, data = data)
 }
 }
 \seealso{

--- a/man/brm_marginal_draws.Rd
+++ b/man/brm_marginal_draws.Rd
@@ -54,13 +54,13 @@ data <- brm_data(
   group = "group",
   time = "time",
   patient = "patient",
-  level_control = "group 1",
-  level_baseline = "time 1"
+  level_control = "group_1",
+  level_baseline = "time_1"
 )
 formula <- brm_formula(
   data = data,
-  effect_base = FALSE,
-  interaction_base = FALSE
+  effect_baseline = FALSE,
+  interaction_baseline = FALSE
 )
 tmp <- utils::capture.output(
   suppressMessages(

--- a/man/brm_marginal_draws_average.Rd
+++ b/man/brm_marginal_draws_average.Rd
@@ -61,7 +61,9 @@ data <- brm_data(
   role = "response",
   group = "group",
   time = "time",
-  patient = "patient"
+  patient = "patient",
+  level_control = "group 1",
+  level_baseline = "time 1"
 )
 formula <- brm_formula(
   data = data,
@@ -81,12 +83,7 @@ tmp <- utils::capture.output(
     )
   )
 )
-draws <- brm_marginal_draws(
-  model = model,
-  data = data,
-  control = "group 1",
-  baseline = "time 1"
-)
+draws <- brm_marginal_draws(model = model, data = data)
 brm_marginal_draws_average(draws = draws, data = data)
 brm_marginal_draws_average(
   draws = draws,

--- a/man/brm_marginal_draws_average.Rd
+++ b/man/brm_marginal_draws_average.Rd
@@ -62,13 +62,13 @@ data <- brm_data(
   group = "group",
   time = "time",
   patient = "patient",
-  level_control = "group 1",
-  level_baseline = "time 1"
+  level_control = "group_1",
+  level_baseline = "time_1"
 )
 formula <- brm_formula(
   data = data,
-  effect_base = FALSE,
-  interaction_base = FALSE
+  effect_baseline = FALSE,
+  interaction_baseline = FALSE
 )
 tmp <- utils::capture.output(
   suppressMessages(
@@ -88,7 +88,7 @@ brm_marginal_draws_average(draws = draws, data = data)
 brm_marginal_draws_average(
   draws = draws,
   data = data,
-  times = c("time 1", "time 2"),
+  times = c("time_1", "time_2"),
   label = "mean"
 )
 }

--- a/man/brm_marginal_probabilities.Rd
+++ b/man/brm_marginal_probabilities.Rd
@@ -48,13 +48,13 @@ data <- brm_data(
   group = "group",
   time = "time",
   patient = "patient",
-  level_control = "group 1",
-  level_baseline = "time 1"
+  level_control = "group_1",
+  level_baseline = "time_1"
 )
 formula <- brm_formula(
   data = data,
-  effect_base = FALSE,
-  interaction_base = FALSE
+  effect_baseline = FALSE,
+  interaction_baseline = FALSE
 )
 tmp <- utils::capture.output(
   suppressMessages(

--- a/man/brm_marginal_probabilities.Rd
+++ b/man/brm_marginal_probabilities.Rd
@@ -47,7 +47,9 @@ data <- brm_data(
   role = "response",
   group = "group",
   time = "time",
-  patient = "patient"
+  patient = "patient",
+  level_control = "group 1",
+  level_baseline = "time 1"
 )
 formula <- brm_formula(
   data = data,
@@ -67,12 +69,7 @@ tmp <- utils::capture.output(
     )
   )
 )
-draws <- brm_marginal_draws(
-  model = model,
-  data = data,
-  control = "group 1",
-  baseline = "time 1"
-)
+draws <- brm_marginal_draws(model = model, data = data)
 brm_marginal_probabilities(draws, direction = "greater", threshold = 0)
 }
 }

--- a/man/brm_marginal_summaries.Rd
+++ b/man/brm_marginal_summaries.Rd
@@ -52,7 +52,9 @@ data <- brm_data(
   role = "response",
   group = "group",
   time = "time",
-  patient = "patient"
+  patient = "patient",
+  level_control = "group 1",
+  level_baseline = "time 1"
 )
 formula <- brm_formula(
   data = data,
@@ -72,12 +74,7 @@ tmp <- utils::capture.output(
     )
   )
 )
-draws <- brm_marginal_draws(
-  model = model,
-  data = data,
-  control = "group 1",
-  baseline = "time 1"
-)
+draws <- brm_marginal_draws(model = model, data = data)
 suppressWarnings(brm_marginal_summaries(draws))
 }
 }

--- a/man/brm_marginal_summaries.Rd
+++ b/man/brm_marginal_summaries.Rd
@@ -53,13 +53,13 @@ data <- brm_data(
   group = "group",
   time = "time",
   patient = "patient",
-  level_control = "group 1",
-  level_baseline = "time 1"
+  level_control = "group_1",
+  level_baseline = "time_1"
 )
 formula <- brm_formula(
   data = data,
-  effect_base = FALSE,
-  interaction_base = FALSE
+  effect_baseline = FALSE,
+  interaction_baseline = FALSE
 )
 tmp <- utils::capture.output(
   suppressMessages(

--- a/man/brm_model.Rd
+++ b/man/brm_model.Rd
@@ -37,7 +37,9 @@ data <- brm_data(
   role = "response",
   group = "group",
   time = "time",
-  patient = "patient"
+  patient = "patient",
+  level_control = "group 1",
+  level_baseline = "time 1"
 )
 formula <- brm_formula(
   data = data,

--- a/man/brm_model.Rd
+++ b/man/brm_model.Rd
@@ -38,13 +38,13 @@ data <- brm_data(
   group = "group",
   time = "time",
   patient = "patient",
-  level_control = "group 1",
-  level_baseline = "time 1"
+  level_control = "group_1",
+  level_baseline = "time_1"
 )
 formula <- brm_formula(
   data = data,
-  effect_base = FALSE,
-  interaction_base = FALSE
+  effect_baseline = FALSE,
+  interaction_baseline = FALSE
 )
 tmp <- utils::capture.output(
   suppressMessages(

--- a/man/brm_plot_compare.Rd
+++ b/man/brm_plot_compare.Rd
@@ -31,8 +31,8 @@ data <- brm_data(
   group = "group",
   time = "time",
   patient = "patient",
-  level_control = "group 1",
-  level_baseline = "time 1"
+  level_control = "group_1",
+  level_baseline = "time_1"
 )
 formula <- brm_formula(
   data = data,

--- a/man/brm_plot_compare.Rd
+++ b/man/brm_plot_compare.Rd
@@ -30,11 +30,13 @@ data <- brm_data(
   role = "response",
   group = "group",
   time = "time",
-  patient = "patient"
+  patient = "patient",
+  level_control = "group 1",
+  level_baseline = "time 1"
 )
 formula <- brm_formula(
   data = data,
-  effect_base = FALSE,
+  effect_baseline = FALSE,
   interaction_base = FALSE
 )
 tmp <- utils::capture.output(
@@ -50,12 +52,7 @@ tmp <- utils::capture.output(
     )
   )
 )
-draws <- brm_marginal_draws(
-  model = model,
-  data = data,
-  control = "group 1",
-  baseline = "time 1"
-)
+draws <- brm_marginal_draws(model = model, data = data)
 suppressWarnings(summaries_draws <- brm_marginal_summaries(draws))
 summaries_data <- brm_marginal_data(data)
 brm_plot_compare(

--- a/man/brm_plot_draws.Rd
+++ b/man/brm_plot_draws.Rd
@@ -25,11 +25,13 @@ data <- brm_data(
   role = "response",
   group = "group",
   time = "time",
-  patient = "patient"
+  patient = "patient",
+  level_control = "group 1",
+  level_baseline = "time 1"
 )
 formula <- brm_formula(
   data = data,
-  effect_base = FALSE,
+  effect_baseline = FALSE,
   interaction_base = FALSE
 )
 tmp <- utils::capture.output(
@@ -45,12 +47,7 @@ tmp <- utils::capture.output(
     )
   )
 )
-draws <- brm_marginal_draws(
-  model = model,
-  data = data,
-  control = "group 1",
-  baseline = "time 1"
-)
+draws <- brm_marginal_draws(model = model, data = data)
 brm_plot_draws(draws = draws$change)
 }
 }

--- a/man/brm_plot_draws.Rd
+++ b/man/brm_plot_draws.Rd
@@ -26,8 +26,8 @@ data <- brm_data(
   group = "group",
   time = "time",
   patient = "patient",
-  level_control = "group 1",
-  level_baseline = "time 1"
+  level_control = "group_1",
+  level_baseline = "time_1"
 )
 formula <- brm_formula(
   data = data,

--- a/tests/testthat/test-brm_data.R
+++ b/tests/testthat/test-brm_data.R
@@ -2,6 +2,9 @@ test_that("brm_data() response", {
   set.seed(0)
   sim <- brm_simulate_simple()
   data <- tibble::as_tibble(sim$data)
+  for (field in c("group", "time", "patient")) {
+    data[[field]] <- gsub("_", " ", data[[field]])
+  }
   data$group <- as.factor(data$group)
   data$factor1 <- data$patient
   data$factor2 <- data$patient
@@ -83,6 +86,9 @@ test_that("brm_data() change", {
   set.seed(0)
   sim <- brm_simulate_simple()
   data <- tibble::as_tibble(sim$data)
+  for (field in c("group", "time", "patient")) {
+    data[[field]] <- gsub("_", " ", data[[field]])
+  }
   data$group <- as.factor(data$group)
   data$factor1 <- data$patient
   data$factor2 <- data$patient

--- a/tests/testthat/test-brm_formula.R
+++ b/tests/testthat/test-brm_formula.R
@@ -3,7 +3,7 @@ test_that("brm_formula() with default names and all terms", {
     data = tibble::tibble(
       CHG = 1,
       AVISIT = "x",
-      BASE = 2,
+      baseline = 2,
       TRT01P = "x",
       USUBJID = "x"
     ),
@@ -11,23 +11,24 @@ test_that("brm_formula() with default names and all terms", {
     role = "change",
     group = "TRT01P",
     time = "AVISIT",
-    base = "BASE",
-    patient = "USUBJID"
+    baseline = "baseline",
+    patient = "USUBJID",
+    level_control = "x"
   )
   out <- brm_formula(
     data = data,
     intercept = TRUE,
     effect_group = TRUE,
     effect_time = TRUE,
-    effect_base = TRUE,
-    interaction_base = TRUE,
+    effect_baseline = TRUE,
+    interaction_baseline = TRUE,
     interaction_group = TRUE
   )
   expect_s3_class(out, "brmsformula")
   expect_equal(
     deparse(out[[1L]], width.cutoff = 500L),
     paste(
-      "CHG ~ AVISIT + BASE + BASE:AVISIT + TRT01P + TRT01P:AVISIT",
+      "CHG ~ AVISIT + baseline + baseline:AVISIT + TRT01P + TRT01P:AVISIT",
       "+ unstr(time = AVISIT, gr = USUBJID)"
     )
   )
@@ -53,17 +54,18 @@ test_that("brm_formula() with all user-supplied columns and all terms", {
     role = "change",
     group = "g",
     time = "t",
-    base = "b",
+    baseline = "b",
     patient = "p",
-    covariates = c("a", "b")
+    covariates = c("a", "b"),
+    level_control = "x"
   )
   out <- brm_formula(
     data = data,
     intercept = TRUE,
     effect_group = TRUE,
     effect_time = TRUE,
-    effect_base = TRUE,
-    interaction_base = TRUE,
+    effect_baseline = TRUE,
+    interaction_baseline = TRUE,
     interaction_group = TRUE
   )
   expect_equal(
@@ -83,7 +85,7 @@ test_that("brm_formula() without intercept", {
     data = tibble::tibble(
       CHG = 1,
       AVISIT = "x",
-      BASE = 2,
+      baseline = 2,
       TRT01P = "x",
       USUBJID = "x"
     ),
@@ -91,22 +93,23 @@ test_that("brm_formula() without intercept", {
     role = "change",
     group = "TRT01P",
     time = "AVISIT",
-    base = "BASE",
-    patient = "USUBJID"
+    baseline = "baseline",
+    patient = "USUBJID",
+    level_control = "x"
   )
   out <- brm_formula(
     data = data,
     intercept = FALSE,
     effect_group = TRUE,
     effect_time = TRUE,
-    effect_base = TRUE,
-    interaction_base = TRUE,
+    effect_baseline = TRUE,
+    interaction_baseline = TRUE,
     interaction_group = TRUE
   )
   expect_equal(
     deparse(out[[1L]], width.cutoff = 500L),
     paste(
-      "CHG ~ 0 + AVISIT + BASE + BASE:AVISIT + TRT01P + TRT01P:AVISIT",
+      "CHG ~ 0 + AVISIT + baseline + baseline:AVISIT + TRT01P + TRT01P:AVISIT",
       "+ unstr(time = AVISIT, gr = USUBJID)"
     )
   )
@@ -123,7 +126,7 @@ test_that("brm_formula() without group effect", {
     data = tibble::tibble(
       CHG = 1,
       AVISIT = "x",
-      BASE = 2,
+      baseline = 2,
       TRT01P = "x",
       USUBJID = "x"
     ),
@@ -131,22 +134,23 @@ test_that("brm_formula() without group effect", {
     role = "change",
     group = "TRT01P",
     time = "AVISIT",
-    base = "BASE",
-    patient = "USUBJID"
+    baseline = "baseline",
+    patient = "USUBJID",
+    level_control = "x"
   )
   out <- brm_formula(
     data = data,
     intercept = TRUE,
     effect_group = FALSE,
     effect_time = TRUE,
-    effect_base = TRUE,
-    interaction_base = TRUE,
+    effect_baseline = TRUE,
+    interaction_baseline = TRUE,
     interaction_group = TRUE
   )
   expect_equal(
     deparse(out[[1L]], width.cutoff = 500L),
     paste(
-      "CHG ~ AVISIT + BASE + BASE:AVISIT + TRT01P:AVISIT",
+      "CHG ~ AVISIT + baseline + baseline:AVISIT + TRT01P:AVISIT",
       "+ unstr(time = AVISIT, gr = USUBJID)"
     )
   )
@@ -163,7 +167,7 @@ test_that("brm_formula() without time effect", {
     data = tibble::tibble(
       CHG = 1,
       AVISIT = "x",
-      BASE = 2,
+      baseline = 2,
       TRT01P = "x",
       USUBJID = "x"
     ),
@@ -171,22 +175,23 @@ test_that("brm_formula() without time effect", {
     role = "change",
     group = "TRT01P",
     time = "AVISIT",
-    base = "BASE",
-    patient = "USUBJID"
+    baseline = "baseline",
+    patient = "USUBJID",
+    level_control = "x"
   )
   out <- brm_formula(
     data = data,
     intercept = TRUE,
     effect_group = TRUE,
     effect_time = FALSE,
-    effect_base = TRUE,
-    interaction_base = TRUE,
+    effect_baseline = TRUE,
+    interaction_baseline = TRUE,
     interaction_group = TRUE
   )
   expect_equal(
     deparse(out[[1L]], width.cutoff = 500L),
     paste(
-      "CHG ~ BASE + BASE:AVISIT + TRT01P + TRT01P:AVISIT",
+      "CHG ~ baseline + baseline:AVISIT + TRT01P + TRT01P:AVISIT",
       "+ unstr(time = AVISIT, gr = USUBJID)"
     )
   )
@@ -203,7 +208,7 @@ test_that("brm_formula() without baseline effect", {
     data = tibble::tibble(
       CHG = 1,
       AVISIT = "x",
-      BASE = 2,
+      baseline = 2,
       TRT01P = "x",
       USUBJID = "x"
     ),
@@ -211,22 +216,23 @@ test_that("brm_formula() without baseline effect", {
     role = "change",
     group = "TRT01P",
     time = "AVISIT",
-    base = "BASE",
-    patient = "USUBJID"
+    baseline = "baseline",
+    patient = "USUBJID",
+    level_control = "x"
   )
   out <- brm_formula(
     data = data,
     intercept = TRUE,
     effect_group = TRUE,
     effect_time = TRUE,
-    effect_base = FALSE,
-    interaction_base = TRUE,
+    effect_baseline = FALSE,
+    interaction_baseline = TRUE,
     interaction_group = TRUE
   )
   expect_equal(
     deparse(out[[1L]], width.cutoff = 500L),
     paste(
-      "CHG ~ AVISIT + BASE:AVISIT + TRT01P + TRT01P:AVISIT",
+      "CHG ~ AVISIT + baseline:AVISIT + TRT01P + TRT01P:AVISIT",
       "+ unstr(time = AVISIT, gr = USUBJID)"
     )
   )
@@ -243,7 +249,7 @@ test_that("brm_formula() without baseline interaction", {
     data = tibble::tibble(
       CHG = 1,
       AVISIT = "x",
-      BASE = 2,
+      baseline = 2,
       TRT01P = "x",
       USUBJID = "x"
     ),
@@ -251,22 +257,23 @@ test_that("brm_formula() without baseline interaction", {
     role = "change",
     group = "TRT01P",
     time = "AVISIT",
-    base = "BASE",
-    patient = "USUBJID"
+    baseline = "baseline",
+    patient = "USUBJID",
+    level_control = "x"
   )
   out <- brm_formula(
     data = data,
     intercept = TRUE,
     effect_group = TRUE,
     effect_time = TRUE,
-    effect_base = TRUE,
-    interaction_base = FALSE,
+    effect_baseline = TRUE,
+    interaction_baseline = FALSE,
     interaction_group = TRUE
   )
   expect_equal(
     deparse(out[[1L]], width.cutoff = 500L),
     paste(
-      "CHG ~ AVISIT + BASE + TRT01P + TRT01P:AVISIT",
+      "CHG ~ AVISIT + baseline + TRT01P + TRT01P:AVISIT",
       "+ unstr(time = AVISIT, gr = USUBJID)"
     )
   )
@@ -283,7 +290,7 @@ test_that("brm_formula() without group interaction", {
     data = tibble::tibble(
       CHG = 1,
       AVISIT = "x",
-      BASE = 2,
+      baseline = 2,
       TRT01P = "x",
       USUBJID = "x"
     ),
@@ -291,22 +298,23 @@ test_that("brm_formula() without group interaction", {
     role = "change",
     group = "TRT01P",
     time = "AVISIT",
-    base = "BASE",
-    patient = "USUBJID"
+    baseline = "baseline",
+    patient = "USUBJID",
+    level_control = "x"
   )
   out <- brm_formula(
     data = data,
     intercept = TRUE,
     effect_group = TRUE,
     effect_time = TRUE,
-    effect_base = TRUE,
-    interaction_base = TRUE,
+    effect_baseline = TRUE,
+    interaction_baseline = TRUE,
     interaction_group = FALSE
   )
   expect_equal(
     deparse(out[[1L]], width.cutoff = 500L),
     paste(
-      "CHG ~ AVISIT + BASE + BASE:AVISIT + TRT01P",
+      "CHG ~ AVISIT + baseline + baseline:AVISIT + TRT01P",
       "+ unstr(time = AVISIT, gr = USUBJID)"
     )
   )

--- a/tests/testthat/test-brm_marginal_data.R
+++ b/tests/testthat/test-brm_marginal_data.R
@@ -7,8 +7,8 @@ test_that("brm_marginal_data()", {
     group = "group",
     time = "time",
     patient = "patient",
-    level_control = "group 1",
-    level_baseline = "time 1"
+    level_control = "group_1",
+    level_baseline = "time_1"
   )
   data$response[1L] <- NA_real_
   out <- brm_marginal_data(

--- a/tests/testthat/test-brm_marginal_data.R
+++ b/tests/testthat/test-brm_marginal_data.R
@@ -6,7 +6,9 @@ test_that("brm_marginal_data()", {
     role = "response",
     group = "group",
     time = "time",
-    patient = "patient"
+    patient = "patient",
+    level_control = "group 1",
+    level_baseline = "time 1"
   )
   data$response[1L] <- NA_real_
   out <- brm_marginal_data(

--- a/tests/testthat/test-brm_marginal_draws.R
+++ b/tests/testthat/test-brm_marginal_draws.R
@@ -8,8 +8,8 @@ test_that("brm_marginal_draws() on response", {
     group = "group",
     time = "time",
     patient = "patient",
-    level_control = "group 1",
-    level_baseline = "time 1"
+    level_control = "group_1",
+    level_baseline = "time_1"
   )
   formula <- brm_formula(
     data = data,
@@ -125,7 +125,7 @@ test_that("brm_marginal_draws() on change", {
     group = "group",
     time = "time",
     patient = "patient",
-    level_control = "group 1"
+    level_control = "group_1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_marginal_draws.R
+++ b/tests/testthat/test-brm_marginal_draws.R
@@ -7,7 +7,9 @@ test_that("brm_marginal_draws() on response", {
     role = "response",
     group = "group",
     time = "time",
-    patient = "patient"
+    patient = "patient",
+    level_control = "group 1",
+    level_baseline = "time 1"
   )
   formula <- brm_formula(
     data = data,
@@ -106,7 +108,8 @@ test_that("brm_marginal_draws() on change", {
     role = "change",
     group = "group",
     time = "time",
-    patient = "patient"
+    patient = "patient",
+    level_control = "group 1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_marginal_draws.R
+++ b/tests/testthat/test-brm_marginal_draws.R
@@ -32,15 +32,13 @@ test_that("brm_marginal_draws() on response", {
   old_sep <- emmeans::get_emm_option("sep")
   out <- brm_marginal_draws(
     model = model,
-    data = data,
-    control = "group.1",
-    baseline = "time.1"
+    data = data
   )
   expect_warning(
     brm_marginal_draws(
       model = model,
       data = data,
-      control = "group.1"
+      control = "group_1"
     ),
     class = "brm_deprecate"
   )
@@ -48,7 +46,7 @@ test_that("brm_marginal_draws() on response", {
     brm_marginal_draws(
       model = model,
       data = data,
-      baseline = "time.1"
+      baseline = "time_1"
     ),
     class = "brm_deprecate"
   )
@@ -72,13 +70,13 @@ test_that("brm_marginal_draws() on response", {
     sort(colnames(out$response)),
     sort(c(columns, names_mcmc))
   )
-  columns_df <- columns_df[columns_df$time != "time.1", ]
+  columns_df <- columns_df[columns_df$time != "time_1", ]
   columns <- paste(columns_df$group, columns_df$time, sep = brm_sep())
   expect_equal(
     sort(colnames(out$change)),
     sort(c(columns, names_mcmc))
   )
-  columns_df <- columns_df[columns_df$group != "group.1", ]
+  columns_df <- columns_df[columns_df$group != "group_1", ]
   columns <- paste(columns_df$group, columns_df$time, sep = brm_sep())
   expect_equal(
     sort(colnames(out$difference)),
@@ -89,9 +87,9 @@ test_that("brm_marginal_draws() on response", {
   colnames(draws) <- gsub("^b_sigma_", "", colnames(draws))
   colnames(draws) <- gsub(paste0("^time"), "", x = colnames(draws))
   sigma <- exp(draws)
-  for (group in setdiff(unique(data$group), "group.1")) {
-    for (time in setdiff(unique(data$time), "time.1")) {
-      name1 <- paste("group.1", time, sep = brm_sep())
+  for (group in setdiff(unique(data$group), "group_1")) {
+    for (time in setdiff(unique(data$time), "time_1")) {
+      name1 <- paste("group_1", time, sep = brm_sep())
       name2 <- paste(group, time, sep = brm_sep())
       expect_equal(
         out$difference[[name2]],
@@ -104,8 +102,8 @@ test_that("brm_marginal_draws() on response", {
     }
   }
   for (group in unique(data$group)) {
-    for (time in setdiff(unique(data$time), "time.1")) {
-      name1 <- paste(group, "time.1", sep = brm_sep())
+    for (time in setdiff(unique(data$time), "time_1")) {
+      name1 <- paste(group, "time_1", sep = brm_sep())
       name2 <- paste(group, time, sep = brm_sep())
       expect_equal(
         out$change[[name2]],
@@ -147,9 +145,7 @@ test_that("brm_marginal_draws() on change", {
   )
   out <- brm_marginal_draws(
     model = model,
-    data = data,
-    control = "group.1",
-    baseline = "time.1"
+    data = data
   )
   fields <- c("response", "difference", "effect")
   columns_df <- expand.grid(
@@ -170,15 +166,15 @@ test_that("brm_marginal_draws() on change", {
     sort(colnames(out$response)),
     sort(c(columns, names_mcmc))
   )
-  columns_df <- columns_df[columns_df$group != "group.1", ]
+  columns_df <- columns_df[columns_df$group != "group_1", ]
   columns <- paste(columns_df$group, columns_df$time, sep = brm_sep())
   expect_equal(
     sort(colnames(out$difference)),
     sort(c(columns, names_mcmc))
   )
-  for (group in setdiff(unique(data$group), "group.1")) {
+  for (group in setdiff(unique(data$group), "group_1")) {
     for (time in unique(data$time)) {
-      name1 <- paste("group.1", time, sep = brm_sep())
+      name1 <- paste("group_1", time, sep = brm_sep())
       name2 <- paste(group, time, sep = brm_sep())
       expect_equal(
         out$difference[[name2]],

--- a/tests/testthat/test-brm_marginal_draws.R
+++ b/tests/testthat/test-brm_marginal_draws.R
@@ -36,6 +36,22 @@ test_that("brm_marginal_draws() on response", {
     control = "group.1",
     baseline = "time.1"
   )
+  expect_warning(
+    brm_marginal_draws(
+      model = model,
+      data = data,
+      control = "group.1"
+    ),
+    class = "brm_deprecate"
+  )
+  expect_warning(
+    brm_marginal_draws(
+      model = model,
+      data = data,
+      baseline = "time.1"
+    ),
+    class = "brm_deprecate"
+  )
   expect_equal(emmeans::get_emm_option("sep"), old_sep)
   fields <- c("response", "change", "difference", "effect")
   columns_df <- expand.grid(

--- a/tests/testthat/test-brm_marginal_draws_average.R
+++ b/tests/testthat/test-brm_marginal_draws_average.R
@@ -7,7 +7,9 @@ test_that("brm_marginal_draws_average()", {
     role = "response",
     group = "group",
     time = "time",
-    patient = "patient"
+    patient = "patient",
+    level_control = "group 1",
+    level_baseline = "time 1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_marginal_draws_average.R
+++ b/tests/testthat/test-brm_marginal_draws_average.R
@@ -29,12 +29,7 @@ test_that("brm_marginal_draws_average()", {
       )
     )
   )
-  out <- brm_marginal_draws(
-    model = model,
-    data = data,
-    control = "group.1",
-    baseline = "time.1"
-  )
+  out <- brm_marginal_draws(model = model, data = data)
   averages_all <- brm_marginal_draws_average(
     draws = out,
     data = data,

--- a/tests/testthat/test-brm_marginal_draws_average.R
+++ b/tests/testthat/test-brm_marginal_draws_average.R
@@ -8,8 +8,8 @@ test_that("brm_marginal_draws_average()", {
     group = "group",
     time = "time",
     patient = "patient",
-    level_control = "group 1",
-    level_baseline = "time 1"
+    level_control = "group_1",
+    level_baseline = "time_1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_marginal_draws_average.R
+++ b/tests/testthat/test-brm_marginal_draws_average.R
@@ -38,10 +38,10 @@ test_that("brm_marginal_draws_average()", {
   averages_sub <- brm_marginal_draws_average(
     draws = out,
     data = data,
-    times = c("time 2", "time 3"),
+    times = c("time_2", "time_3"),
     label = "mean"
   )
-  for (group in setdiff(unique(data$group), "group.1")) {
+  for (group in setdiff(unique(data$group), "group_1")) {
     cols_all <- grep(
       pattern = group,
       x = colnames(out$response),
@@ -49,7 +49,7 @@ test_that("brm_marginal_draws_average()", {
       value = TRUE
     )
     cols_sub <- grep(
-      pattern = "time\\.2|time\\.3",
+      pattern = "time_2|time_3",
       x = cols_all,
       fixed = FALSE,
       value = TRUE

--- a/tests/testthat/test-brm_marginal_probabilities.R
+++ b/tests/testthat/test-brm_marginal_probabilities.R
@@ -42,12 +42,12 @@ test_that("brm_marginal_probabilities() on response", {
     sort(colnames(x)),
     sort(c("group", "time", "direction", "threshold", "value"))
   )
-  expect_equal(x$group, rep("group.2", 3))
-  expect_equal(x$time, paste0("time.", seq(2, 4)))
+  expect_equal(x$group, rep("group_2", 3))
+  expect_equal(x$time, paste0("time_", seq(2, 4)))
   expect_equal(x$direction, rep("greater", 3))
   expect_equal(x$threshold, rep(0, 3))
   column <- function(group, time) {
-    sprintf("group.%s%stime.%s", group, brm_sep(), time)
+    sprintf("group_%s%stime_%s", group, brm_sep(), time)
   }
   expect_equal(
     x$value[1L],
@@ -109,8 +109,8 @@ test_that("brm_marginal_probabilities() on change and multiple probs", {
     sort(colnames(x)),
     sort(c("group", "time", "direction", "threshold", "value"))
   )
-  expect_equal(x$group, rep("group.2", 8))
-  expect_equal(x$time, rep(paste0("time.", seq(1, 4)), times = 2))
+  expect_equal(x$group, rep("group_2", 8))
+  expect_equal(x$time, rep(paste0("time_", seq(1, 4)), times = 2))
   expect_equal(x$direction, rep(c("greater", "less"), each = 4))
   expect_equal(x$threshold, c(rep(30, 4), rep(15, 4)))
   expect_equal(x$value, rep(c(0.4, 0.28), each = 4L))

--- a/tests/testthat/test-brm_marginal_probabilities.R
+++ b/tests/testthat/test-brm_marginal_probabilities.R
@@ -7,7 +7,9 @@ test_that("brm_marginal_probabilities() on response", {
     role = "response",
     group = "group",
     time = "time",
-    patient = "patient"
+    patient = "patient",
+    level_control = "group 1",
+    level_baseline = "time 1"
   )
   formula <- brm_formula(
     data = data,
@@ -72,7 +74,8 @@ test_that("brm_marginal_probabilities() on change and multiple probs", {
     role = "change",
     group = "group",
     time = "time",
-    patient = "patient"
+    patient = "patient",
+    level_control = "group 1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_marginal_probabilities.R
+++ b/tests/testthat/test-brm_marginal_probabilities.R
@@ -31,9 +31,7 @@ test_that("brm_marginal_probabilities() on response", {
   )
   draws <- brm_marginal_draws(
     model = model,
-    data = data,
-    control = "group.1",
-    baseline = "time.1"
+    data = data
   )
   x <- brm_marginal_probabilities(
     draws,
@@ -97,9 +95,7 @@ test_that("brm_marginal_probabilities() on change and multiple probs", {
   )
   draws <- brm_marginal_draws(
     model = model,
-    data = data,
-    control = "group.1",
-    baseline = "time.1"
+    data = data
   )
   for (index in seq_along(draws$difference)) {
     draws$difference[[index]] <- seq_len(nrow(draws$difference))

--- a/tests/testthat/test-brm_marginal_probabilities.R
+++ b/tests/testthat/test-brm_marginal_probabilities.R
@@ -8,8 +8,8 @@ test_that("brm_marginal_probabilities() on response", {
     group = "group",
     time = "time",
     patient = "patient",
-    level_control = "group 1",
-    level_baseline = "time 1"
+    level_control = "group_1",
+    level_baseline = "time_1"
   )
   formula <- brm_formula(
     data = data,
@@ -73,7 +73,7 @@ test_that("brm_marginal_probabilities() on change and multiple probs", {
     group = "group",
     time = "time",
     patient = "patient",
-    level_control = "group 1"
+    level_control = "group_1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_marginal_summaries.R
+++ b/tests/testthat/test-brm_marginal_summaries.R
@@ -31,9 +31,7 @@ test_that("brm_marginal_summaries() on response", {
   )
   draws <- brm_marginal_draws(
     model = model,
-    data = data,
-    control = "group.1",
-    baseline = "time.1"
+    data = data
   )
   suppressWarnings(
     x <- brm_marginal_summaries(
@@ -152,9 +150,7 @@ test_that("brm_marginal_summaries() on change", {
   )
   draws <- brm_marginal_draws(
     model = model,
-    data = data,
-    control = "group.1",
-    baseline = "time.1"
+    data = data
   )
   suppressWarnings(
     x <- brm_marginal_summaries(

--- a/tests/testthat/test-brm_marginal_summaries.R
+++ b/tests/testthat/test-brm_marginal_summaries.R
@@ -8,8 +8,8 @@ test_that("brm_marginal_summaries() on response", {
     group = "group",
     time = "time",
     patient = "patient",
-    level_control = "group 1",
-    level_baseline = "time 1"
+    level_control = "group_1",
+    level_baseline = "time_1"
   )
   formula <- brm_formula(
     data = data,
@@ -128,7 +128,7 @@ test_that("brm_marginal_summaries() on change", {
     group = "group",
     time = "time",
     patient = "patient",
-    level_control = "group 1"
+    level_control = "group_1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_marginal_summaries.R
+++ b/tests/testthat/test-brm_marginal_summaries.R
@@ -7,7 +7,9 @@ test_that("brm_marginal_summaries() on response", {
     role = "response",
     group = "group",
     time = "time",
-    patient = "patient"
+    patient = "patient",
+    level_control = "group 1",
+    level_baseline = "time 1"
   )
   formula <- brm_formula(
     data = data,
@@ -127,7 +129,8 @@ test_that("brm_marginal_summaries() on change", {
     role = "change",
     group = "group",
     time = "time",
-    patient = "patient"
+    patient = "patient",
+    level_control = "group 1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_model.R
+++ b/tests/testthat/test-brm_model.R
@@ -8,8 +8,8 @@ test_that("brm_model() runs", {
     group = "group",
     time = "time",
     patient = "patient",
-    level_control = "group 1",
-    level_baseline = "time 1"
+    level_control = "group_1",
+    level_baseline = "time_1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_model.R
+++ b/tests/testthat/test-brm_model.R
@@ -7,7 +7,9 @@ test_that("brm_model() runs", {
     role = "response",
     group = "group",
     time = "time",
-    patient = "patient"
+    patient = "patient",
+    level_control = "group 1",
+    level_baseline = "time 1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_plot_compare.R
+++ b/tests/testthat/test-brm_plot_compare.R
@@ -31,9 +31,7 @@ test_that("brm_plot_compare()", {
   )
   draws <- brm_marginal_draws(
     model = model,
-    data = data,
-    control = "group.1",
-    baseline = "time.1"
+    data = data
   )
   suppressWarnings(summaries_draws <- brm_marginal_summaries(draws))
   summaries_data <- brm_marginal_data(data)

--- a/tests/testthat/test-brm_plot_compare.R
+++ b/tests/testthat/test-brm_plot_compare.R
@@ -7,7 +7,9 @@ test_that("brm_plot_compare()", {
     role = "response",
     group = "group",
     time = "time",
-    patient = "patient"
+    patient = "patient",
+    level_control = "group 1",
+    level_baseline = "time 1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_plot_compare.R
+++ b/tests/testthat/test-brm_plot_compare.R
@@ -8,8 +8,8 @@ test_that("brm_plot_compare()", {
     group = "group",
     time = "time",
     patient = "patient",
-    level_control = "group 1",
-    level_baseline = "time 1"
+    level_control = "group_1",
+    level_baseline = "time_1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_plot_draws.R
+++ b/tests/testthat/test-brm_plot_draws.R
@@ -7,7 +7,9 @@ test_that("brm_plot_draws()", {
     role = "response",
     group = "group",
     time = "time",
-    patient = "patient"
+    patient = "patient",
+    level_control = "group 1",
+    level_baseline = "time 1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_plot_draws.R
+++ b/tests/testthat/test-brm_plot_draws.R
@@ -31,9 +31,7 @@ test_that("brm_plot_draws()", {
   )
   draws <- brm_marginal_draws(
     model = model,
-    data = data,
-    control = "group.1",
-    baseline = "time.1"
+    data = data
   )
   out <- brm_plot_draws(draws = draws$change)
   expect_s3_class(out, "ggplot")

--- a/tests/testthat/test-brm_plot_draws.R
+++ b/tests/testthat/test-brm_plot_draws.R
@@ -8,8 +8,8 @@ test_that("brm_plot_draws()", {
     group = "group",
     time = "time",
     patient = "patient",
-    level_control = "group 1",
-    level_baseline = "time 1"
+    level_control = "group_1",
+    level_baseline = "time_1"
   )
   formula <- brm_formula(
     data = data,

--- a/tests/testthat/test-brm_simulate_outline.R
+++ b/tests/testthat/test-brm_simulate_outline.R
@@ -23,7 +23,7 @@ test_that("brm_simulate_outline() compounded missingness", {
     rate_dropout = 0.5,
     rate_lapse = 0.5
   )
-  data <- data[data$time != "time 1", ]
+  data <- data[data$time != "time_1", ]
   expect_true(mean(data$missing) > 0.65)
 })
 
@@ -37,8 +37,8 @@ test_that("brm_simulate_outline() lapsed missing", {
     rate_dropout = 0,
     rate_lapse = 0.57
   )
-  expect_false(any(data$time == "time 1" & data$missing))
-  data <- data[data$time != "time 1", ]
+  expect_false(any(data$time == "time_1" & data$missing))
+  data <- data[data$time != "time_1", ]
   expect_equal(mean(data$missing), 0.57, tolerance = 0.01)
   for (level in unique(data$group)) {
     out <- dplyr::filter(data, group == level)
@@ -56,7 +56,7 @@ test_that("brm_simulate_outline() dropout at final time point", {
     rate_dropout = 0.37,
     rate_lapse = 0
   )
-  data <- data[data$time == "time 4", ]
+  data <- data[data$time == "time_4", ]
   expect_equal(mean(data$missing), 0.37, tolerance = 0.01)
   for (level in unique(data$group)) {
     out <- dplyr::filter(data, group == level)
@@ -95,7 +95,7 @@ test_that("brm_simulate_outline() correct dropout times", {
     rate_dropout = 1,
     rate_lapse = 0
   )
-  data <- data[data$time != "time 1", ]
+  data <- data[data$time != "time_1", ]
   data <- data %>%
     group_by(patient) %>%
     summarize(drop = min(which(missing)), .groups = "drop")

--- a/tests/testthat/test-brm_simulate_outline.R
+++ b/tests/testthat/test-brm_simulate_outline.R
@@ -7,12 +7,22 @@ test_that("brm_simulate_outline() grid", {
     rate_lapse = 0.5
   )
   expect_equal(nrow(data), 1716L)
-  expect_equal(data$group, paste("group", rep(seq_len(11L), each = 12L * 13L)))
+  for (field in c("group", "patient", "time")) {
+    data[[field]] <- as.integer(gsub(paste0(field, "_"), "", data[[field]]))
+  }
+  data <- dplyr::arrange(data, group, patient, time)
+  expect_equal(
+    data$group,
+    rep(seq_len(11L), each = 12L * 13L)
+  )
   expect_equal(
     data$patient,
-    paste("patient", rep(seq_len(11L * 12L), each = 13L))
+    rep(seq_len(11L * 12L), each = 13L)
   )
-  expect_equal(data$time, paste("time", rep(seq_len(13L), times = 11L * 12L)))
+  expect_equal(
+    data$time,
+    rep(seq_len(13L), times = 11L * 12L)
+  )
 })
 
 test_that("brm_simulate_outline() compounded missingness", {

--- a/tests/testthat/test-brm_simulate_simple.R
+++ b/tests/testthat/test-brm_simulate_simple.R
@@ -12,9 +12,9 @@ test_that("brm_simulate_simple() data", {
   expect_equal(dim(data), c(12L, 4L))
   expect_true(is.numeric(data$response))
   expect_false(anyNA(data$response))
-  expect_equal(data$group, paste("group", rep(seq_len(2L), each = 6L)))
-  expect_equal(data$patient, paste("patient", rep(seq_len(4L), each = 3L)))
-  levels_time <- paste("time", seq_len(3L))
+  expect_equal(data$group, paste0("group_", rep(seq_len(2L), each = 6L)))
+  expect_equal(data$patient, paste0("patient_", rep(seq_len(4L), each = 3L)))
+  levels_time <- paste0("time_", seq_len(3L))
   expect_equal(data$time, rep(levels_time, times = 4L))
 })
 
@@ -32,15 +32,15 @@ test_that("brm_simulate_simple() model_matrix", {
   expect_equal(dim(matrix), c(12L, 4L))
   colnames(matrix) <- gsub("^group", "", colnames(matrix))
   colnames(matrix) <- gsub("^time", "", colnames(matrix))
-  expect_equal(as.integer(matrix[, "group 1"]), rep(c(1L, 0L), each = 6L))
-  expect_equal(as.integer(matrix[, "group 2"]), rep(c(0L, 1L), each = 6L))
+  expect_equal(as.integer(matrix[, "group_1"]), rep(c(1L, 0L), each = 6L))
+  expect_equal(as.integer(matrix[, "group_2"]), rep(c(0L, 1L), each = 6L))
   expect_equal(
-    as.integer(matrix[, "time 2"]),
-    as.integer(out$data$time == "time 2")
+    as.integer(matrix[, "time_2"]),
+    as.integer(out$data$time == "time_2")
   )
   expect_equal(
-    as.integer(matrix[, "time 3"]),
-    as.integer(out$data$time == "time 3")
+    as.integer(matrix[, "time_3"]),
+    as.integer(out$data$time == "time_3")
   )
 })
 

--- a/vignettes/usage.Rmd
+++ b/vignettes/usage.Rmd
@@ -41,7 +41,7 @@ raw_data <- brm_simulate_simple(
 raw_data
 ```
 
-Next, create a special classed dataset that the package will recognize. The classed data object contains a pre-processed version of the data, along with attributes to declare the outcome variable, whether the outcome is response or change from baseline, the treatment group variable, the discrete time point variable, and other details.
+Next, create a special classed dataset that the package will recognize. The classed data object contains a pre-processed version of the data, along with attributes to declare the outcome variable, whether the outcome is response or change from baseline, the treatment group variable, the discrete time point variable, control group, baseline time point, and other details.
 
 ```{r}
 data <- brm_data(
@@ -50,7 +50,9 @@ data <- brm_data(
   role = "response",
   group = "group",
   patient = "patient",
-  time = "time"
+  time = "time",
+  level_control = "group_1",
+  level_baseline = "time_1"
 )
 
 data
@@ -62,8 +64,6 @@ roles$row.names <- NULL
 str(roles)
 ```
 
-Above, the levels of the `group` and `time` columns are automatically cleaned with `make.names()` to ensure alignment between the data and `brms` output. Whenever `brms.mmrm` calls `make.names()`, it always sets `unique = FALSE` and `allow_ = TRUE`.
-
 # Formula
 
 Next, choose a `brms` model formula for the fixed effect and variance parameters. The `brm_formula()` function from `brms.mmrm` makes this process easier. A cell means parameterization for this particular model can be expressed as follows. It specifies one fixed effect parameter for each combination of treatment group and time point, and it makes the specification of informative priors straightforward through the `prior` argument of `brm_model()`.
@@ -72,10 +72,10 @@ Next, choose a `brms` model formula for the fixed effect and variance parameters
 brm_formula(
   data = data,
   intercept = FALSE,
-  effect_base = FALSE,
+  effect_baseline = FALSE,
   effect_group = FALSE,
   effect_time = FALSE,
-  interaction_base = FALSE,
+  interaction_baseline = FALSE,
   interaction_group = TRUE
 )
 ```
@@ -86,10 +86,10 @@ For the purposes of our example, we choose a fully parameterized analysis of the
 formula <- brm_formula(
   data = data,
   intercept = TRUE,
-  effect_base = FALSE,
+  effect_baseline = FALSE,
   effect_group = TRUE,
   effect_time = TRUE,
-  interaction_base = FALSE,
+  interaction_baseline = FALSE,
   interaction_group = TRUE
 )
 
@@ -134,12 +134,7 @@ Regardless of the choice of fixed effects formula, `brms.mmrm` performs inferenc
 To derive posterior draws of these marginals, use the `brm_marginal_draws()` function.
 
 ```{r, paged.print = FALSE}
-draws <- brm_marginal_draws(
-  model = model,
-  data = data,
-  control = "group 1", # automatically cleaned with make.names()
-  baseline = "time 1" # also cleaned with make.names()
-)
+draws <- brm_marginal_draws(model = model, data = data)
 
 draws
 ```


### PR DESCRIPTION
* Add roles for the missing values column (from simulations), the level of the control group, and the level of baseline.
* Add the analogous new arguments to `brm_data()`.
* Migrate non-deprecated simulation functions to use the `brm_data` class.
* Deprecate arguments `control` and `baseline` of `brm_marginal_draws()` in favor of the attributes that get assigned during `brm_data()`.
* Change the term "base" to "baseline` in `brm_data()` and `brm_formula()`.

These changes put `brms.mmrm` on better footing to continue with #3.