### PR TITLE
Alternative correlation and variance options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: brms.mmrm
 Title: Bayesian MMRMs using 'brms'
-Version: 0.1.0.9001
+Version: 0.1.0.9002
 Authors@R: c(
   person(
     given = c("William", "Michael"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# brms.mmrm 0.1.0.9001 (development)
+# brms.mmrm 0.1.0.9002 (development)
 
 ## Guardrails to ensure the appropriateness of marginal mean estimation
 
@@ -16,6 +16,10 @@
 * Use `brm_transform_marginal()` instead of `emmeans` in `brm_marginal_draws()` to derive posterior draws of marginal means based on posterior draws of model parameters (#53).
 * Explain the custom marginal mean calculation in a new `inference.Rmd` vignette.
 * Rename `methods.Rmd` to `model.Rmd` since `inference.Rmd` also discusses methods.
+
+## Covariances
+
+* Extend `brm_formula()` and `brm_marginal_draws()` to optionally model homogeneous variances, as well as ARMA, AR, MA, and compound symmetry correlation structures.
 
 # brms.mmrm 0.1.0
 

--- a/R/brm_formula.R
+++ b/R/brm_formula.R
@@ -30,8 +30,45 @@
 #'   correlation structure, and residual variance structure.
 #' @param data A classed data frame from [brm_data()].
 #' @param correlation Character of length 1, name of the correlation
-#'   structure. Choose `"unstructured"` for unstructured covariance
-#'   or `"diagonal"` for independent time points within patients.
+#'   structure. The correlation matrix is a square `T x T` matrix, where
+#'   `T` is the number of discrete time points in the data.
+#'   This matrix describes the correlations between time points in the same
+#'   patient, as modeled in the residuals. Different patients are modeled
+#'   as independent. The `correlation` argument controls how this matrix
+#'   is parameterized, and the choices given by `brms` are listed at
+#'   <https://paul-buerkner.github.io/brms/reference/autocor-terms.html>,
+#'   and the choice is ultimately encoded in the main body of the
+#'   output formula through terms like `unstru()` and `arma()`, some
+#'   of which are configurable through arguments
+#'   `autoregressive_order`, `moving_average_order`, and
+#'   `residual_covariance_arma_estimation` of [brm_formula()].
+#'   Choices in `brms.mmrm`:
+#'   * `"unstructured"`: the default/recommended option, a fully parameterized
+#'     covariance matrix with a unique scalar parameter for each unique pair
+#'     of discrete time points. C.f.
+#'     <https://paul-buerkner.github.io/brms/reference/unstr.html>.
+#'   * `"autoregressive_moving_average"`: autoregressive moving
+#'     average (ARMA), c.f.
+#'     <https://paul-buerkner.github.io/brms/reference/arma.html>.
+#'   * `"autoregressive"`: autoregressive (AR), c.f.
+#'     <https://paul-buerkner.github.io/brms/reference/ar.html>.
+#'   * `"moving_average"`: moving average (MA), c.f.
+#'     <https://paul-buerkner.github.io/brms/reference/ma.html>.
+#'   * `"compound_symmetry`: compound symmetry, c.f.
+#'     <https://paul-buerkner.github.io/brms/reference/cosy.html>.
+#'   * `"diagonal"`: declare independent time points within patients.
+#' @param autoregressive_order Nonnegative integer,
+#'   autoregressive order for the `"autoregressive_moving_average"`
+#'   and `"autoregressive"` correlation structures.
+#' @param moving_average_order Nonnegative integer,
+#'   moving average order for the `"autoregressive_moving_average"`
+#'   and `"moving_average"` correlation structures.
+#' @param residual_covariance_arma_estimation `TRUE` or `FALSE`,
+#'   whether to estimate ARMA effects using residual covariance matrices.
+#'   Directly supplied to the `cov` argument in `brms` for
+#'   `"autoregressive_moving_average"`, `"autoregressive"`, and
+#'   `"moving_average"` correlation structures. C.f.
+#'   <https://paul-buerkner.github.io/brms/reference/arma.html>.
 #' @param variance Character of length 1, variance structure for the
 #'   residuals. `"heterogeneous"` declares a different variance component
 #'   for each discrete time point, `"homogeneous"` declares a single
@@ -42,6 +79,12 @@
 #'   The variance components are encoded as parameters `b_sigma` in the model.
 #'   Each `b_sigma` is a standard deviation of residuals on the natural
 #'   log scale.
+#'
+#'   The variance structure is encoded in the
+#'   `sigma ~ ...` part of the output formula. To see the variance
+#'   parameterization for yourself, use `brms::make_standata()`
+#'   on the formula and data, or `brms::prior_summary()` or
+#'   `posterior::as_draws_df()` on the model.
 #' @param intercept Logical of length 1.
 #'   `TRUE` (default) to include an intercept, `FALSE` to omit.
 #' @param baseline Logical of length 1.
@@ -151,6 +194,9 @@ brm_formula <- function(
   time = TRUE,
   covariates = TRUE,
   correlation = "unstructured",
+  autoregressive_order = 1L,
+  moving_average_order = 1L,
+  residual_covariance_arma_estimation = FALSE,
   variance = "heterogeneous",
   effect_baseline = NULL,
   effect_group = NULL,
@@ -173,6 +219,26 @@ brm_formula <- function(
   assert_lgl(subgroup_time, sprintf(text, "subgroup_time"))
   assert_lgl(time, sprintf(text, "time"))
   assert_lgl(covariates, sprintf(text, "covariates"))
+  assert_lgl(
+    residual_covariance_arma_estimation,
+    sprintf(text, "residual_covariance_arma_estimation")
+  )
+  assert(
+    autoregressive_order,
+    is.numeric(.),
+    !anyNA(.),
+    length(.) == 1L,
+    . >= 0,
+    message = "autoregressive_order must be a nonnegative integer of length 1"
+  )
+  assert(
+    moving_average_order,
+    is.numeric(.),
+    !anyNA(.),
+    length(.) == 1L,
+    . >= 0,
+    message = "moving_average_order must be a nonnegative integer of length 1"
+  )
   expect_baseline <- baseline ||
     baseline_subgroup ||
     baseline_subgroup_time ||
@@ -243,7 +309,14 @@ brm_formula <- function(
     term(c(name_subgroup, name_time), subgroup_time),
     term(name_time, time),
     unlist(lapply(name_covariates, term, condition = covariates)),
-    term_correlation(correlation, name_time, name_patient)
+    term_correlation(
+      correlation = correlation,
+      name_time = name_time,
+      name_patient = name_patient,
+      autoregressive_order = autoregressive_order,
+      moving_average_order = moving_average_order,
+      residual_covariance_arma_estimation
+    )
   )
   terms <- terms[nzchar(terms)]
   right <- paste(terms, collapse = " + ")
@@ -270,6 +343,10 @@ brm_formula <- function(
     brm_time = time,
     brm_covariates = covariates,
     brm_correlation = correlation,
+    brm_autoregressive_order = autoregressive_order,
+    brm_moving_average_order = moving_average_order,
+    brm_residual_covariance_arma_estimation =
+      residual_covariance_arma_estimation,
     brm_variance = variance
   )
   brm_formula_validate(formula)
@@ -292,6 +369,9 @@ brm_formula_new <- function(
   brm_time,
   brm_covariates,
   brm_correlation,
+  brm_autoregressive_order,
+  brm_moving_average_order,
+  brm_residual_covariance_arma_estimation,
   brm_variance
 ) {
   structure(
@@ -311,6 +391,10 @@ brm_formula_new <- function(
     brm_time = brm_time,
     brm_covariates = brm_covariates,
     brm_correlation = brm_correlation,
+    brm_autoregressive_order = brm_autoregressive_order,
+    brm_moving_average_order = brm_moving_average_order,
+    brm_residual_covariance_arma_estimation =
+      brm_residual_covariance_arma_estimation,
     brm_variance = brm_variance
   )
 }
@@ -343,6 +427,26 @@ brm_formula_validate <- function(formula) {
       message = paste(attribute, "attribute must be TRUE or FALSE in formula")
     )
   }
+  assert_lgl(
+    attr(formula, "brm_residual_covariance_arma_estimation"),
+    message = "residual_covariance_arma_estimation must be TRUE or FALSE"
+  )
+  assert(
+    attr(formula, "brm_autoregressive_order"),
+    is.numeric(.),
+    !anyNA(.),
+    length(.) == 1L,
+    . >= 0,
+    message = "autoregressive_order must be a nonnegative integer of length 1"
+  )
+  assert(
+    attr(formula, "brm_moving_average_order"),
+    is.numeric(.),
+    !anyNA(.),
+    length(.) == 1L,
+    . >= 0,
+    message = "moving_average_order must be a nonnegative integer of length 1"
+  )
   brm_formula_validate_correlation(attr(formula, "brm_correlation"))
   brm_formula_validate_variance(attr(formula, "brm_variance"))
 }
@@ -352,7 +456,14 @@ brm_formula_validate_correlation <- function(correlation) {
     correlation,
     "correlation arg must be a nonempty character string"
   )
-  choices <- c("unstructured", "diagonal")
+  choices <- c(
+    "unstructured",
+    "autoregressive_moving_average",
+    "autoregressive",
+    "moving_average",
+    "compound_symmetry",
+    "diagonal"
+  )
   assert(
     correlation %in% choices,
     message = paste(
@@ -404,13 +515,32 @@ term <- function(labels, condition) {
   if_any(condition, paste0(labels, collapse = ":"), character(0L))
 }
 
-term_correlation <- function(correlation, name_time, name_patient) {
-  switch(
+term_correlation <- function(
+  correlation,
+  name_time,
+  name_patient,
+  autoregressive_order,
+  moving_average_order,
+  residual_covariance_arma_estimation
+) {
+  if (identical(as.character(correlation), "diagonal")) {
+    return(NULL)
+  }
+  fun <- switch(
     correlation,
-    unstructured = sprintf(
-      "unstr(time = %s, gr = %s)",
-      name_time,
-      name_patient
-    )
+    unstructured = "unstr",
+    autoregressive_moving_average = "arma",
+    autoregressive = "ar",
+    moving_average = "ma",
+    compound_symmetry = "cosy"
   )
+  args <- list(
+    time = as.symbol(name_time),
+    gr = as.symbol(name_patient),
+    p = autoregressive_order,
+    q = moving_average_order,
+    cov = residual_covariance_arma_estimation
+  )[names(formals(getNamespace("brms")[[fun]]))]
+  call <- as.call(c(as.symbol(fun), args))
+  paste(deparse(call), collapse = " ")
 }

--- a/R/brm_marginal_draws.R
+++ b/R/brm_marginal_draws.R
@@ -218,7 +218,7 @@ brm_marginal_draws <- function(
       )
     }
   }
-  draws_sigma <- get_draws_sigma(model = model, time = time)
+  draws_sigma <- get_draws_sigma_heterogeneous(model = model, time = time)
   draws_effect <- if_any(
     has_subgroup,
     get_draws_effect_subgroup(
@@ -226,13 +226,15 @@ brm_marginal_draws <- function(
       draws_sigma = draws_sigma,
       levels_group = levels_group,
       levels_subgroup = levels_subgroup,
-      levels_time = levels_time
+      levels_time = levels_time,
+      variance = attr(formula, "brm_variance")
     ),
     get_draws_effect(
       draws_difference_group = draws_difference_group,
       draws_sigma = draws_sigma,
       levels_group = levels_group,
-      levels_time = levels_time
+      levels_time = levels_time,
+      variance = attr(formula, "brm_variance")
     )
   )
   out <- list()
@@ -248,7 +250,7 @@ brm_marginal_draws <- function(
   out
 }
 
-get_draws_sigma <- function(model, time) {
+get_draws_sigma_heterogeneous <- function(model, time) {
   draws <- tibble::as_tibble(posterior::as_draws_df(model))
   draws <- draws[, grep("^b_sigma_", colnames(draws), value = TRUE)]
   colnames(draws) <- gsub("^b_sigma_", "", colnames(draws))
@@ -260,14 +262,20 @@ get_draws_effect <- function(
   draws_difference_group,
   draws_sigma,
   levels_group,
-  levels_time
+  levels_time,
+  variance
 ) {
   out <- draws_difference_group
   for (group in levels_group) {
     for (time in levels_time) {
       name <- name_marginal(group = group, time = time)
+      sigma <- if_any(
+        variance == "heterogeneous",
+        draws_sigma[[time]],
+        draws_sigma[[1L]]
+      )
       if (name %in% colnames(draws_difference_group)) {
-        out[[name]] <- draws_difference_group[[name]] / draws_sigma[[time]]
+        out[[name]] <- draws_difference_group[[name]] / sigma
       }
     }
   }
@@ -279,7 +287,8 @@ get_draws_effect_subgroup <- function(
   draws_sigma,
   levels_group,
   levels_subgroup,
-  levels_time
+  levels_time,
+  variance
 ) {
   out <- draws_difference_group
   for (group in levels_group) {
@@ -290,8 +299,13 @@ get_draws_effect_subgroup <- function(
           subgroup = subgroup,
           time = time
         )
+        sigma <- if_any(
+          variance == "heterogeneous",
+          draws_sigma[[time]],
+          draws_sigma[[1L]]
+        )
         if (name %in% colnames(draws_difference_group)) {
-          out[[name]] <- draws_difference_group[[name]] / draws_sigma[[time]]
+          out[[name]] <- draws_difference_group[[name]] / sigma
         }
       }
     }

--- a/R/brm_marginal_draws.R
+++ b/R/brm_marginal_draws.R
@@ -218,7 +218,7 @@ brm_marginal_draws <- function(
       )
     }
   }
-  draws_sigma <- get_draws_sigma_heterogeneous(model = model, time = time)
+  draws_sigma <- get_draws_sigma(model = model, time = time)
   draws_effect <- if_any(
     has_subgroup,
     get_draws_effect_subgroup(
@@ -250,7 +250,7 @@ brm_marginal_draws <- function(
   out
 }
 
-get_draws_sigma_heterogeneous <- function(model, time) {
+get_draws_sigma <- function(model, time) {
   draws <- tibble::as_tibble(posterior::as_draws_df(model))
   draws <- draws[, grep("^b_sigma_", colnames(draws), value = TRUE)]
   colnames(draws) <- gsub("^b_sigma_", "", colnames(draws))

--- a/man/brm_formula.Rd
+++ b/man/brm_formula.Rd
@@ -22,6 +22,7 @@ brm_formula(
   time = TRUE,
   covariates = TRUE,
   correlation = "unstructured",
+  variance = "heterogeneous",
   effect_baseline = NULL,
   effect_group = NULL,
   effect_time = NULL,
@@ -97,6 +98,17 @@ the \code{covariates} argument of \code{\link[=brm_data]{brm_data()}},
 \item{correlation}{Character of length 1, name of the correlation
 structure. Choose \code{"unstructured"} for unstructured covariance
 or \code{"diagonal"} for independent time points within patients.}
+
+\item{variance}{Character of length 1, variance structure for the
+residuals. \code{"heterogeneous"} declares a different variance component
+for each discrete time point, \code{"homogeneous"} declares a single
+scalar variance shared by all time points. In either case, the variance
+components are shared by all patients, and different patients are
+modeled as independent.
+
+The variance components are encoded as parameters \code{b_sigma} in the model.
+Each \code{b_sigma} is a standard deviation of residuals on the natural
+log scale.}
 
 \item{effect_baseline}{Deprecated on 2024-01-16 (version 0.0.2.9002).
 Use \code{baseline} instead.}

--- a/man/brm_formula.Rd
+++ b/man/brm_formula.Rd
@@ -22,6 +22,9 @@ brm_formula(
   time = TRUE,
   covariates = TRUE,
   correlation = "unstructured",
+  autoregressive_order = 1L,
+  moving_average_order = 1L,
+  residual_covariance_arma_estimation = FALSE,
   variance = "heterogeneous",
   effect_baseline = NULL,
   effect_group = NULL,
@@ -96,8 +99,50 @@ the \code{covariates} argument of \code{\link[=brm_data]{brm_data()}},
 \code{FALSE} to omit.}
 
 \item{correlation}{Character of length 1, name of the correlation
-structure. Choose \code{"unstructured"} for unstructured covariance
-or \code{"diagonal"} for independent time points within patients.}
+structure. The correlation matrix is a square \verb{T x T} matrix, where
+\code{T} is the number of discrete time points in the data.
+This matrix describes the correlations between time points in the same
+patient, as modeled in the residuals. Different patients are modeled
+as independent. The \code{correlation} argument controls how this matrix
+is parameterized, and the choices given by \code{brms} are listed at
+\url{https://paul-buerkner.github.io/brms/reference/autocor-terms.html},
+and the choice is ultimately encoded in the main body of the
+output formula through terms like \code{unstru()} and \code{arma()}, some
+of which are configurable through arguments
+\code{autoregressive_order}, \code{moving_average_order}, and
+\code{residual_covariance_arma_estimation} of \code{\link[=brm_formula]{brm_formula()}}.
+Choices in \code{brms.mmrm}:
+\itemize{
+\item \code{"unstructured"}: the default/recommended option, a fully parameterized
+covariance matrix with a unique scalar parameter for each unique pair
+of discrete time points. C.f.
+\url{https://paul-buerkner.github.io/brms/reference/unstr.html}.
+\item \code{"autoregressive_moving_average"}: autoregressive moving
+average (ARMA), c.f.
+\url{https://paul-buerkner.github.io/brms/reference/arma.html}.
+\item \code{"autoregressive"}: autoregressive (AR), c.f.
+\url{https://paul-buerkner.github.io/brms/reference/ar.html}.
+\item \code{"moving_average"}: moving average (MA), c.f.
+\url{https://paul-buerkner.github.io/brms/reference/ma.html}.
+\item \verb{"compound_symmetry}: compound symmetry, c.f.
+\url{https://paul-buerkner.github.io/brms/reference/cosy.html}.
+\item \code{"diagonal"}: declare independent time points within patients.
+}}
+
+\item{autoregressive_order}{Nonnegative integer,
+autoregressive order for the \code{"autoregressive_moving_average"}
+and \code{"autoregressive"} correlation structures.}
+
+\item{moving_average_order}{Nonnegative integer,
+moving average order for the \code{"autoregressive_moving_average"}
+and \code{"moving_average"} correlation structures.}
+
+\item{residual_covariance_arma_estimation}{\code{TRUE} or \code{FALSE},
+whether to estimate ARMA effects using residual covariance matrices.
+Directly supplied to the \code{cov} argument in \code{brms} for
+\code{"autoregressive_moving_average"}, \code{"autoregressive"}, and
+\code{"moving_average"} correlation structures. C.f.
+\url{https://paul-buerkner.github.io/brms/reference/arma.html}.}
 
 \item{variance}{Character of length 1, variance structure for the
 residuals. \code{"heterogeneous"} declares a different variance component
@@ -108,7 +153,13 @@ modeled as independent.
 
 The variance components are encoded as parameters \code{b_sigma} in the model.
 Each \code{b_sigma} is a standard deviation of residuals on the natural
-log scale.}
+log scale.
+
+The variance structure is encoded in the
+\code{sigma ~ ...} part of the output formula. To see the variance
+parameterization for yourself, use \code{brms::make_standata()}
+on the formula and data, or \code{brms::prior_summary()} or
+\code{posterior::as_draws_df()} on the model.}
 
 \item{effect_baseline}{Deprecated on 2024-01-16 (version 0.0.2.9002).
 Use \code{baseline} instead.}

--- a/tests/testthat/test-brm_formula.R
+++ b/tests/testthat/test-brm_formula.R
@@ -25,6 +25,8 @@ test_that("brm_formula() with default names and all non-subgroup terms", {
     time = TRUE
   )
   expect_s3_class(out, "brmsformula")
+  expect_equal(attr(out, "brm_correlation"), "unstructured")
+  expect_equal(attr(out, "brm_variance"), "heterogeneous")
   expect_equal(
     deparse(out[[1L]], width.cutoff = 500L),
     paste(
@@ -36,6 +38,51 @@ test_that("brm_formula() with default names and all non-subgroup terms", {
     deparse(out[[2L]][[1L]], width.cutoff = 500L),
     paste(
       "sigma ~ 0 + AVISIT"
+    )
+  )
+})
+
+test_that("brm_formula() same with homogeneous variance", {
+  data <- brm_data(
+    data = tibble::tibble(
+      CHG = 1,
+      AVISIT = "x",
+      baseline = 2,
+      TRT01P = "x",
+      USUBJID = "x"
+    ),
+    outcome = "CHG",
+    role = "change",
+    group = "TRT01P",
+    time = "AVISIT",
+    baseline = "baseline",
+    patient = "USUBJID",
+    reference_group = "x"
+  )
+  out <- brm_formula(
+    data = data,
+    intercept = TRUE,
+    baseline = TRUE,
+    baseline_time = TRUE,
+    group = TRUE,
+    group_time = TRUE,
+    time = TRUE,
+    variance = "homogeneous"
+  )
+  expect_s3_class(out, "brmsformula")
+  expect_equal(attr(out, "brm_correlation"), "unstructured")
+  expect_equal(attr(out, "brm_variance"), "homogeneous")
+  expect_equal(
+    deparse(out[[1L]], width.cutoff = 500L),
+    paste(
+      "CHG ~ baseline + baseline:AVISIT + TRT01P + TRT01P:AVISIT + AVISIT",
+      "+ unstr(time = AVISIT, gr = USUBJID)"
+    )
+  )
+  expect_equal(
+    deparse(out[[2L]][[1L]], width.cutoff = 500L),
+    paste(
+      "sigma ~ 1"
     )
   )
 })

--- a/tests/testthat/test-brm_formula.R
+++ b/tests/testthat/test-brm_formula.R
@@ -87,6 +87,151 @@ test_that("brm_formula() same with homogeneous variance", {
   )
 })
 
+test_that("brm_formula() different correlation structures", {
+  data <- brm_data(
+    data = tibble::tibble(
+      CHG = 1,
+      AVISIT = "x",
+      baseline = 2,
+      TRT01P = "x",
+      USUBJID = "x"
+    ),
+    outcome = "CHG",
+    role = "change",
+    group = "TRT01P",
+    time = "AVISIT",
+    baseline = "baseline",
+    patient = "USUBJID",
+    reference_group = "x"
+  )
+  out <- brm_formula(
+    data = data,
+    intercept = TRUE,
+    baseline = TRUE,
+    baseline_time = TRUE,
+    group = TRUE,
+    group_time = TRUE,
+    time = TRUE,
+    correlation = "autoregressive_moving_average"
+  )
+  expect_equal(
+    deparse(out[[1L]], width.cutoff = 500L),
+    paste(
+      "CHG ~ baseline + baseline:AVISIT + TRT01P + TRT01P:AVISIT + AVISIT",
+      "+ arma(time = AVISIT, gr = USUBJID, p = 1L, q = 1L, cov = FALSE)"
+    )
+  )
+  out <- brm_formula(
+    data = data,
+    intercept = TRUE,
+    baseline = TRUE,
+    baseline_time = TRUE,
+    group = TRUE,
+    group_time = TRUE,
+    time = TRUE,
+    correlation = "autoregressive_moving_average",
+    autoregressive_order = 2L,
+    moving_average_order = 3L,
+    residual_covariance_arma_estimation = TRUE
+  )
+  expect_equal(
+    deparse(out[[1L]], width.cutoff = 500L),
+    paste(
+      "CHG ~ baseline + baseline:AVISIT + TRT01P + TRT01P:AVISIT + AVISIT",
+      "+ arma(time = AVISIT, gr = USUBJID, p = 2L, q = 3L, cov = TRUE)"
+    )
+  )
+  out <- brm_formula(
+    data = data,
+    intercept = TRUE,
+    baseline = TRUE,
+    baseline_time = TRUE,
+    group = TRUE,
+    group_time = TRUE,
+    time = TRUE,
+    correlation = "autoregressive"
+  )
+  expect_equal(
+    deparse(out[[1L]], width.cutoff = 500L),
+    paste(
+      "CHG ~ baseline + baseline:AVISIT + TRT01P + TRT01P:AVISIT + AVISIT",
+      "+ ar(time = AVISIT, gr = USUBJID, p = 1L, cov = FALSE)"
+    )
+  )
+  out <- brm_formula(
+    data = data,
+    intercept = TRUE,
+    baseline = TRUE,
+    baseline_time = TRUE,
+    group = TRUE,
+    group_time = TRUE,
+    time = TRUE,
+    correlation = "autoregressive",
+    autoregressive_order = 3L,
+    residual_covariance_arma_estimation = TRUE
+  )
+  expect_equal(
+    deparse(out[[1L]], width.cutoff = 500L),
+    paste(
+      "CHG ~ baseline + baseline:AVISIT + TRT01P + TRT01P:AVISIT + AVISIT",
+      "+ ar(time = AVISIT, gr = USUBJID, p = 3L, cov = TRUE)"
+    )
+  )
+  out <- brm_formula(
+    data = data,
+    intercept = TRUE,
+    baseline = TRUE,
+    baseline_time = TRUE,
+    group = TRUE,
+    group_time = TRUE,
+    time = TRUE,
+    correlation = "moving_average"
+  )
+  expect_equal(
+    deparse(out[[1L]], width.cutoff = 500L),
+    paste(
+      "CHG ~ baseline + baseline:AVISIT + TRT01P + TRT01P:AVISIT + AVISIT",
+      "+ ma(time = AVISIT, gr = USUBJID, q = 1L, cov = FALSE)"
+    )
+  )
+  out <- brm_formula(
+    data = data,
+    intercept = TRUE,
+    baseline = TRUE,
+    baseline_time = TRUE,
+    group = TRUE,
+    group_time = TRUE,
+    time = TRUE,
+    correlation = "moving_average",
+    moving_average_order = 5L,
+    residual_covariance_arma_estimation = TRUE
+  )
+  expect_equal(
+    deparse(out[[1L]], width.cutoff = 500L),
+    paste(
+      "CHG ~ baseline + baseline:AVISIT + TRT01P + TRT01P:AVISIT + AVISIT",
+      "+ ma(time = AVISIT, gr = USUBJID, q = 5L, cov = TRUE)"
+    )
+  )
+  out <- brm_formula(
+    data = data,
+    intercept = TRUE,
+    baseline = TRUE,
+    baseline_time = TRUE,
+    group = TRUE,
+    group_time = TRUE,
+    time = TRUE,
+    correlation = "compound_symmetry"
+  )
+  expect_equal(
+    deparse(out[[1L]], width.cutoff = 500L),
+    paste(
+      "CHG ~ baseline + baseline:AVISIT + TRT01P + TRT01P:AVISIT + AVISIT",
+      "+ cosy(time = AVISIT, gr = USUBJID)"
+    )
+  )
+})
+
 test_that("brm_formula() with default names and all terms", {
   data <- brm_data(
     data = tibble::tibble(

--- a/tests/testthat/test-brm_marginal_draws.R
+++ b/tests/testthat/test-brm_marginal_draws.R
@@ -32,7 +32,8 @@ test_that("brm_marginal_draws() on response, no subgroup", {
   out <- brm_marginal_draws(
     model = model,
     formula = formula,
-    data = data
+    data = data,
+    transform = brm_transform_marginal(data = data, formula = formula)
   )
   expect_warning(
     brm_marginal_draws(
@@ -151,7 +152,12 @@ test_that("brm_marginal_draws() on response, with subgroup", {
     ),
     class = "brm_deprecate"
   )
-  out <- brm_marginal_draws(model = model, formula = formula, data = data)
+  out <- brm_marginal_draws(
+    model = model,
+    formula = formula,
+    data = data,
+    transform = brm_transform_marginal(data = data, formula = formula)
+  )
   fields <- c(
     "response",
     "difference_time",
@@ -297,7 +303,8 @@ test_that("brm_marginal_draws() on change, homogeneous var, no subgroup", {
   out <- brm_marginal_draws(
     model = model,
     formula = formula,
-    data = data
+    data = data,
+    transform = brm_transform_marginal(data = data, formula = formula)
   )
   fields <- c("response", "difference_group", "effect")
   columns_df <- expand.grid(
@@ -324,6 +331,11 @@ test_that("brm_marginal_draws() on change, homogeneous var, no subgroup", {
     sort(colnames(out$difference_group)),
     sort(c(columns, names_mcmc))
   )
+  draws <- tibble::as_tibble(posterior::as_draws_df(model))
+  draws <- draws[, grep("^b_sigma_", colnames(draws), value = TRUE)]
+  colnames(draws) <- gsub("^b_sigma_", "", colnames(draws))
+  colnames(draws) <- gsub(paste0("^time"), "", x = colnames(draws))
+  sigma <- exp(draws)
   for (group in setdiff(unique(data$group), "group_1")) {
     for (time in unique(data$time)) {
       name1 <- paste("group_1", time, sep = brm_sep())
@@ -331,6 +343,10 @@ test_that("brm_marginal_draws() on change, homogeneous var, no subgroup", {
       expect_equal(
         out$difference_group[[name2]],
         out$response[[name2]] - out$response[[name1]]
+      )
+      expect_equal(
+        out$effect[[name2]],
+        out$difference_group[[name2]] / sigma[[1L]]
       )
     }
   }
@@ -351,7 +367,7 @@ test_that("brm_marginal_draws() on change, homogeneous var, with subgroup", {
     name_change = "change",
     name_baseline = "baseline"
   )
-  formula <- brm_formula(data = data)
+  formula <- brm_formula(data = data, variance = "homogeneous")
   tmp <- utils::capture.output(
     suppressMessages(
       suppressWarnings(
@@ -369,7 +385,7 @@ test_that("brm_marginal_draws() on change, homogeneous var, with subgroup", {
     model = model,
     formula = formula,
     data = data,
-    variance = "homogeneous"
+    transform = brm_transform_marginal(data = data, formula = formula)
   )
   fields <- c("response", "difference_group", "difference_subgroup", "effect")
   expect_equal(sort(names(out)), sort(fields))
@@ -430,6 +446,11 @@ test_that("brm_marginal_draws() on change, homogeneous var, with subgroup", {
       }
     }
   }
+  draws <- tibble::as_tibble(posterior::as_draws_df(model))
+  draws <- draws[, grep("^b_sigma_", colnames(draws), value = TRUE)]
+  colnames(draws) <- gsub("^b_sigma_", "", colnames(draws))
+  colnames(draws) <- gsub(paste0("^time"), "", x = colnames(draws))
+  sigma <- exp(draws)
   for (group in setdiff(unique(data$group), "group_1")) {
     for (subgroup in setdiff(unique(data$subgroup), "subgroup_1")) {
       for (time in unique(data$time)) {
@@ -438,6 +459,10 @@ test_that("brm_marginal_draws() on change, homogeneous var, with subgroup", {
         expect_equal(
           out$difference_subgroup[[name2]],
           out$difference_group[[name2]] - out$difference_group[[name1]]
+        )
+        expect_equal(
+          out$effect[[name2]],
+          out$difference_group[[name2]] / sigma[[1L]]
         )
       }
     }

--- a/tests/testthat/test-brm_marginal_draws.R
+++ b/tests/testthat/test-brm_marginal_draws.R
@@ -263,7 +263,7 @@ test_that("brm_marginal_draws() on response, with subgroup", {
   }
 })
 
-test_that("brm_marginal_draws() on change, no subgroup", {
+test_that("brm_marginal_draws() on change, homogeneous var, no subgroup", {
   skip_on_cran()
   set.seed(0L)
   data <- brm_data(
@@ -278,7 +278,8 @@ test_that("brm_marginal_draws() on change, no subgroup", {
   formula <- brm_formula(
     data = data,
     baseline = FALSE,
-    baseline_time = FALSE
+    baseline_time = FALSE,
+    variance = "homogeneous"
   )
   tmp <- utils::capture.output(
     suppressMessages(
@@ -335,7 +336,7 @@ test_that("brm_marginal_draws() on change, no subgroup", {
   }
 })
 
-test_that("brm_marginal_draws() on change, with subgroup", {
+test_that("brm_marginal_draws() on change, homogeneous var, with subgroup", {
   skip_on_cran()
   set.seed(0L)
   data <- brm_simulate_outline(
@@ -367,7 +368,8 @@ test_that("brm_marginal_draws() on change, with subgroup", {
   out <- brm_marginal_draws(
     model = model,
     formula = formula,
-    data = data
+    data = data,
+    variance = "homogeneous"
   )
   fields <- c("response", "difference_group", "difference_subgroup", "effect")
   expect_equal(sort(names(out)), sort(fields))

--- a/tests/testthat/test-brm_marginal_draws_average.R
+++ b/tests/testthat/test-brm_marginal_draws_average.R
@@ -30,7 +30,12 @@ test_that("brm_marginal_draws_average() non-subgroup", {
     )
   )
   suppressMessages(
-    out <- brm_marginal_draws(model = model, formula = formula, data = data)
+    out <- brm_marginal_draws(
+      model = model,
+      formula = formula,
+      data = data,
+      transform = brm_transform_marginal(data = data, formula = formula)
+    )
   )
   averages_all <- brm_marginal_draws_average(
     draws = out,
@@ -123,7 +128,12 @@ test_that("brm_marginal_draws_average() subgroup", {
       )
     )
   )
-  out <- brm_marginal_draws(model = model, formula = formula, data = data)
+  out <- brm_marginal_draws(
+    model = model,
+    formula = formula,
+    data = data,
+    transform = brm_transform_marginal(data = data, formula = formula)
+  )
   averages_all <- brm_marginal_draws_average(
     draws = out,
     data = data,

--- a/vignettes/model.Rmd
+++ b/vignettes/model.Rmd
@@ -18,13 +18,31 @@ The `brms.mmrm` R package implements a mixed model of repeated measures (MMRM), 
 
 The MMRM in `brms.mmrm` is mathematically expressed as follows. Subsequent sections define notation, data, parameters, and priors.
 
+## Heterogeneous variance model
+
+If the user selects heterogeneous variance in `brm_formula()`, then the model is expressed as follows.
+
 $$
 \begin{aligned}
 &y_i \stackrel{\text{ind}}{\sim} \text{Multivariate-Normal} \left (\text{mean} = X_{i} \beta, \ \text{covariance} = \text{diag}(\sigma) \cdot \Lambda \cdot \text{diag}(\sigma) \right ) \\
 &\qquad \beta_p \stackrel{\text{ind}}{\sim} q_p() \\
 &\qquad \Lambda \sim r() \\
+&\qquad \tau_t = \log(\sigma_t) \\
+&\qquad \qquad \tau_t \stackrel{\text{ind}}{\sim} s()
+\end{aligned}
+$$
+
+## Homogeneous variance model
+
+If the user select homogeneous variance in `brm_formula()`, then all discrete time points share the same standard deviation parameter, and $\sigma$ and $\tau$ are scalars instead of vectors.
+
+$$
+\begin{aligned}
+&y_i \stackrel{\text{ind}}{\sim} \text{Multivariate-Normal} \left (\text{mean} = X_{i} \beta, \ \text{covariance} =  \sigma^2 \Lambda  \right ) \\
+&\qquad \beta_p \stackrel{\text{ind}}{\sim} q_p() \\
+&\qquad \Lambda \sim r() \\
 &\qquad \tau = \log(\sigma) \\
-&\qquad \qquad \tau_t \stackrel{\text{ind}}{\sim} s_t()
+&\qquad \qquad \tau \sim s()
 \end{aligned}
 $$
 
@@ -46,16 +64,16 @@ $$
 
 * $\beta$: vector of model coefficients. $\beta_p$ is scalar element $p$ of $\beta$. In subgroup analysis, $\beta$ contains model coefficients for different subgroup levels, as well as any interaction terms declared through the model formula.
 * $\Lambda$: matrix of pairwise correlations among each pair of time points within subjects. Outcomes measured from different subjects are assumed to be independent, and outcomes observed at different time points for the same subject are assumed to be correlated according to this matrix. $\Lambda$ is positive-definite and symmetric, and the number of rows and columns is equal to the number of discrete time points of the study. 
-* $\sigma$: vector of time-point-specific standard deviations of the residuals on the linear scale. $\sigma_t$ is scalar element $t$ of $\sigma$.
-* $\tau$: same as $\sigma$, but on the natural logarithmic scale. Each scalar element $\tau_t$ of $\tau$ is defined as the natural logarithm of $\sigma_t$.
+* $\sigma$: in the heterogeneous variance model, $\sigma$ is a vector of time-point-specific standard deviations of the residuals on the linear scale. $\sigma_t$ is scalar element $t$ of $\sigma$. In the homogeneous variance model, $\sigma$ is a scalar shared by all time points.
+* $\tau$: same as $\sigma$, but on the natural logarithmic scale. In the heterogeneous variance case, $\tau$ is a vector of time-specific elements $\tau_t$, and each scalar element $\tau_t$ of $\tau$ is defined as the natural logarithm of $\sigma_t$. In the homogeneous variance case, $\tau$ is a scalar, still on the natural log scale (log of $\sigma$).
 
 # Priors
 
 The priors on the parameters depend on the `prior` argument of `brm_model()` and related functions. If priors are not specified by the user, then the [`brms`](https://paul-buerkner.github.io/brms/) package sets defaults. You can view the default priors using the [`get_prior()`](http://paul-buerkner.github.io/brms/reference/get_prior.html) function in [`brms`](https://paul-buerkner.github.io/brms/). See the [`brms`](https://paul-buerkner.github.io/brms/) for information on how [`brms`](https://paul-buerkner.github.io/brms/) sets default priors.
 
 * $q_p()$: univariate prior on the model coefficient $\beta_p$.
-* $r()$: matrix prior on the within-subject residual correlation matrix parameter $\Lambda$.
-* $s_t()$: univariate prior on the natural-log-standard-deviation parameter $\tau_t$ of discrete time point $t$.
+* $r()$: matrix prior on the within-subject residual correlation matrix parameter $\Lambda$. Can be unstructured, autoregressive moving average, autoregressive, moving average, or compound symmetry, c.f. <https://paul-buerkner.github.io/brms/reference/autocor-terms.html>.
+* $s()$: univariate prior on the scalar components of the natural-log-standard-deviation parameter $\tau$. The components of $\tau$ are assumed independent and identically distributed with this univariate prior.
 
 # Sampling
 


### PR DESCRIPTION
* Support homogeneous variance through `brm_formula()` (and adapt brm_marginal_draws()`).
* Support ARMA, AR, MA, and compound symmetry correlation structures through `brm_formula()`.
* Update the `model.Rmd` vignette, `brm_formula()` help file, and tests to reflect the above.

Fixes #88