### PR TITLE
Interface improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: brms.mmrm
 Title: Bayesian MMRMs using 'brms'
-Version: 1.0.1.9005
+Version: 1.0.1.9006
 Authors@R: c(
   person(
     given = c("William", "Michael"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,15 @@
-# brms.mmrm 1.0.1.9005 (development)
+# brms.mmrm 1.0.1.9006 (development)
 
 * Add `brm_marginal_grid()`.
 * Show posterior samples of `sigma` in `brm_marginal_draws()` and `brm_marginal_summaries()`.
 * Allow `outcome = "response"` with `reference_time = NULL`. Sometimes raw response is analyzed but the data has no baseline time point.
 * Preserve factors in `brm_data()` and encourage ordered factors for the time variable (#113).
 * Add `brm_data_chronologize()` to ensure the correctness of the time variable.
-* Do not drop columns in `brm_data()`. This helps `brm_data_chronologize()` operate correctly after calls to `brm_data()
+* Do not drop columns in `brm_data()`. This helps `brm_data_chronologize()` operate correctly after calls to `brm_data()`.
+* Add new elements `brms.mmrm_data` and `brms.mmrm_formula` to the `brms` fitted model object returned by `brm_model()`.
+* Take defaults `data` and `formula` from the above in `brm_marginal_draws()`.
+* Set the default value of `effect_size` to `attr(formula, "brm_allow_effect_size")`.
+* Remove defaults from some arguments to `brm_data()` and document examples.
 
 # brms.mmrm 1.0.1
 

--- a/R/brm_data.R
+++ b/R/brm_data.R
@@ -24,15 +24,22 @@
 #' @return A classed tibble with attributes which denote features of
 #'   the data such as the treatment group and discrete time variables.
 #' @param data Data frame or tibble with longitudinal data.
-#' @param outcome Character of length 1, name of the outcome variable.
+#' @param outcome Character of length 1, name of the continuous
+#'   outcome variable.
+#'   Example possibilities from clinical trial datasets include
+#'   `"CHG"` and `"AVAL"`.
+#'   The `outcome` column in the data should be a numeric vector.
 #' @param role Character of length 1. Either `"response"` if `outcome`
 #'   is the raw response variable (e.g. AVAL) or `"change"` if `outcome`
 #'   is change from baseline (e.g. CHG).
 #' @param baseline Character of length 1,
-#'   name of the baseline response variable.
+#'   name of the baseline response variable (for example, `"BASE"`
+#'   in many clinical trial datasets).
 #'   Only relevant if the response variable is change from baseline.
 #'   Supply `NULL` to ignore or omit.
 #' @param group Character of length 1, name of the treatment group variable.
+#'   Example possibilities from clinical trial datasets include
+#'   `"TRT01P"`, `"TREATMENT"`, `"TRT"`, and `"GROUP"`.
 #'   The `group` column in the data should be a
 #'   character vector or unordered factor.
 #' @param subgroup Character of length 1, optional name of the a
@@ -40,8 +47,10 @@
 #'   If present, the `subgroup` column in the data should be a
 #'   character vector or unordered factor.
 #' @param time Character of length 1, name of the discrete time variable.
-#'   For most analyses, please use an ordered factor for the `time` column
-#'   in the data. You can easily turn
+#'   Example possibilities from clinical trial datasets include
+#'   `"AVISIT"` and `"VISIT"`.
+#'   For most analyses, please ensure the time column in the data
+#'   is an ordered factor. You can easily turn
 #'   the time variable into an ordered factor using
 #'   [brm_data_chronologize()], either before or immediately after
 #'   [brm_data()] (but before any `brm_archetype_*()` functions).
@@ -57,12 +66,19 @@
 #'   manually set `contrasts(data[[time]])` to something else after
 #'   calling [brm_data()].
 #' @param patient Character of length 1, name of the patient ID variable.
+#'   Example possibilities from clinical trial datasets include
+#'   `"USUBJID"`, `"SUBJID"`, `"PATIENT"`, `"PATIENTID"`, `"SUBJECT"`,
+#'   `"SUBJIDID"`, `"SBJID"`, `"STYSID1A"`, `"SBJ1N"`, and `"ID"`.
+#'   The `patient` column in the data should be a factor or character vector.
 #' @param covariates Character vector of names of other covariates.
 #' @param missing Character of length 1, name of an optional variable
 #'   in a simulated dataset to indicate which outcome values should be missing.
 #'   Set to `NULL` to omit.
 #' @param reference_group Atomic value of length 1, Level of the `group`
 #'   column to indicate the control group.
+#'   Example possibilities from clinical trial datasets include
+#'   `"Placebo"`, `"PLACEBO"`, `"PBO"`, `"PLB"`, `"CONTROL"`, `"CTRL"`,
+#'   `"REFERENCE"`, and `"REF"`.
 #'   `reference_group` only applies to the post-processing that happens
 #'   in functions like [brm_marginal_draws()] downstream of the model.
 #'   It does not control the fixed effect mapping in the
@@ -107,16 +123,16 @@
 #' )
 brm_data <- function(
   data,
-  outcome = "CHG",
+  outcome,
   role = "change",
   baseline = NULL,
-  group = "TRT01P",
+  group,
   subgroup = NULL,
-  time = "AVISIT",
-  patient = "USUBJID",
+  time,
+  patient,
   covariates = character(0L),
   missing = NULL,
-  reference_group = "Placebo",
+  reference_group,
   reference_subgroup = NULL,
   reference_time = NULL,
   level_baseline = NULL,

--- a/R/brm_marginal_draws.R
+++ b/R/brm_marginal_draws.R
@@ -57,6 +57,12 @@
 #'   no longer marginalizes over the subgroup declared
 #'   in [brm_data()]. To marginalize over the subgroup, declare
 #'   that variable in `covariates` instead.
+#' @param average_within_subgroup `TRUE`, `FALSE`, or `NULL` to control
+#'   whether nuisance parameters are averaged within subgroup levels
+#'   in [brm_transform_marginal()]. Ignored if the `transform` argument
+#'   is manually supplied by the user. See the help page of
+#'   [brm_transform_marginal()] for details on the
+#'   `average_within_subgroup` argument.
 #' @param control Deprecated. Set the control group level in [brm_data()].
 #' @param baseline Deprecated. Set the control group level in [brm_data()].
 #' @examples
@@ -93,11 +99,16 @@
 #' brm_marginal_draws(data = data, formula = formula, model = model)
 #' }
 brm_marginal_draws <- function(
-  data,
-  formula,
   model,
-  transform = brms.mmrm::brm_transform_marginal(data, formula),
-  effect_size = TRUE,
+  data = model$brms.mmrm_data,
+  formula = model$brms.mmrm_formula,
+  transform = brms.mmrm::brm_transform_marginal(
+    data = data,
+    formula = formula,
+    average_within_subgroup = average_within_subgroup
+  ),
+  effect_size = attr(formula, "brm_allow_effect_size"),
+  average_within_subgroup = NULL,
   use_subgroup = NULL,
   control = NULL,
   baseline = NULL

--- a/R/brm_marginal_draws_average.R
+++ b/R/brm_marginal_draws_average.R
@@ -79,8 +79,8 @@
 #' )
 #' }
 brm_marginal_draws_average <- function(
-  data,
   draws,
+  data,
   times = NULL,
   label = "average"
 ) {

--- a/R/brm_model.R
+++ b/R/brm_model.R
@@ -3,7 +3,9 @@
 #' @family models
 #' @description Fit an MMRM model using `brms`.
 #' @inheritSection brm_formula Parameterization
-#' @return A fitted model object from `brms`.
+#' @return A fitted model object from `brms`, with new list elements
+#'   `brms.mmrm_data` and `brms.mmrm_formula` to capture the data
+#'   and formula used to fit the model.
 #' @inheritParams brm_formula
 #' @param formula An object of class `"brmsformula"` from [brm_formula()]
 #'   or `brms::brmsformula()`. Should include the full mapping
@@ -58,10 +60,13 @@
 #'     )
 #'   )
 #' )
-#' # The output model is a brms model fit object.
+#' # The output is a brms model fit object with added list
+#' # elements "brms.mmrm_data" and "brms.mmrm_formula" to track the dataset
+#' # and formula used to fit the model.
+#' model$brms.mmrm_data
+#' model$brms.mmrm_formula
+#' # Otherwise, the fitted model object acts exactly like a brms fitted model.
 #' suppressWarnings(print(model))
-#' # The `prior_summary()` function shows the full prior specification
-#' # which reflects the fully realized fixed effects mapping.
 #' brms::prior_summary(model)
 #' }
 brm_model <- function(
@@ -84,12 +89,14 @@ brm_model <- function(
     prior = prior,
     ...
   )
-  model <- brm_model_new(model, formula)
+  model <- brm_model_new(model, data, formula)
   brm_model_validate(model)
   model
 }
 
-brm_model_new <- function(model, formula) {
+brm_model_new <- function(model, data, formula) {
+  model$brms.mmrm_data <- data
+  model$brms.mmrm_formula <- formula
   structure(
     model,
     class = unique(c("brms_mmrm_model", class(model)))
@@ -107,6 +114,8 @@ brm_model_validate <- function(model) {
       "in brms.mmrm may not be statistically valid."
     )
   )
+  brm_data_validate(model$brms.mmrm_data)
+  brm_formula_validate(model$brms.mmrm_formula)
 }
 
 brms_model_validate_family <- function(family) {

--- a/man/brm_data.Rd
+++ b/man/brm_data.Rd
@@ -6,16 +6,16 @@
 \usage{
 brm_data(
   data,
-  outcome = "CHG",
+  outcome,
   role = "change",
   baseline = NULL,
-  group = "TRT01P",
+  group,
   subgroup = NULL,
-  time = "AVISIT",
-  patient = "USUBJID",
+  time,
+  patient,
   covariates = character(0L),
   missing = NULL,
-  reference_group = "Placebo",
+  reference_group,
   reference_subgroup = NULL,
   reference_time = NULL,
   level_baseline = NULL,
@@ -25,18 +25,25 @@ brm_data(
 \arguments{
 \item{data}{Data frame or tibble with longitudinal data.}
 
-\item{outcome}{Character of length 1, name of the outcome variable.}
+\item{outcome}{Character of length 1, name of the continuous
+outcome variable.
+Example possibilities from clinical trial datasets include
+\code{"CHG"} and \code{"AVAL"}.
+The \code{outcome} column in the data should be a numeric vector.}
 
 \item{role}{Character of length 1. Either \code{"response"} if \code{outcome}
 is the raw response variable (e.g. AVAL) or \code{"change"} if \code{outcome}
 is change from baseline (e.g. CHG).}
 
 \item{baseline}{Character of length 1,
-name of the baseline response variable.
+name of the baseline response variable (for example, \code{"BASE"}
+in many clinical trial datasets).
 Only relevant if the response variable is change from baseline.
 Supply \code{NULL} to ignore or omit.}
 
 \item{group}{Character of length 1, name of the treatment group variable.
+Example possibilities from clinical trial datasets include
+\code{"TRT01P"}, \code{"TREATMENT"}, \code{"TRT"}, and \code{"GROUP"}.
 The \code{group} column in the data should be a
 character vector or unordered factor.}
 
@@ -46,8 +53,10 @@ If present, the \code{subgroup} column in the data should be a
 character vector or unordered factor.}
 
 \item{time}{Character of length 1, name of the discrete time variable.
-For most analyses, please use an ordered factor for the \code{time} column
-in the data. You can easily turn
+Example possibilities from clinical trial datasets include
+\code{"AVISIT"} and \code{"VISIT"}.
+For most analyses, please ensure the time column in the data
+is an ordered factor. You can easily turn
 the time variable into an ordered factor using
 \code{\link[=brm_data_chronologize]{brm_data_chronologize()}}, either before or immediately after
 \code{\link[=brm_data]{brm_data()}} (but before any \verb{brm_archetype_*()} functions).
@@ -63,7 +72,11 @@ using \code{\link[=contr.treatment]{contr.treatment()}}. If you prefer different
 manually set \code{contrasts(data[[time]])} to something else after
 calling \code{\link[=brm_data]{brm_data()}}.}
 
-\item{patient}{Character of length 1, name of the patient ID variable.}
+\item{patient}{Character of length 1, name of the patient ID variable.
+Example possibilities from clinical trial datasets include
+\code{"USUBJID"}, \code{"SUBJID"}, \code{"PATIENT"}, \code{"PATIENTID"}, \code{"SUBJECT"},
+\code{"SUBJIDID"}, \code{"SBJID"}, \code{"STYSID1A"}, \code{"SBJ1N"}, and \code{"ID"}.
+The \code{patient} column in the data should be a factor or character vector.}
 
 \item{covariates}{Character vector of names of other covariates.}
 
@@ -73,6 +86,9 @@ Set to \code{NULL} to omit.}
 
 \item{reference_group}{Atomic value of length 1, Level of the \code{group}
 column to indicate the control group.
+Example possibilities from clinical trial datasets include
+\code{"Placebo"}, \code{"PLACEBO"}, \code{"PBO"}, \code{"PLB"}, \code{"CONTROL"}, \code{"CTRL"},
+\code{"REFERENCE"}, and \code{"REF"}.
 \code{reference_group} only applies to the post-processing that happens
 in functions like \code{\link[=brm_marginal_draws]{brm_marginal_draws()}} downstream of the model.
 It does not control the fixed effect mapping in the

--- a/man/brm_marginal_draws.Rd
+++ b/man/brm_marginal_draws.Rd
@@ -5,17 +5,21 @@
 \title{MCMC draws from the marginal posterior of an MMRM}
 \usage{
 brm_marginal_draws(
-  data,
-  formula,
   model,
-  transform = brms.mmrm::brm_transform_marginal(data, formula),
-  effect_size = TRUE,
+  data = model$brms.mmrm_data,
+  formula = model$brms.mmrm_formula,
+  transform = brms.mmrm::brm_transform_marginal(data = data, formula = formula,
+    average_within_subgroup = average_within_subgroup),
+  effect_size = attr(formula, "brm_allow_effect_size"),
+  average_within_subgroup = NULL,
   use_subgroup = NULL,
   control = NULL,
   baseline = NULL
 )
 }
 \arguments{
+\item{model}{A fitted model object from \code{\link[=brm_model]{brm_model()}}.}
+
 \item{data}{A classed data frame from \code{\link[=brm_data]{brm_data()}}, or an informative
 prior archetype from a function like \code{\link[=brm_archetype_successive_cells]{brm_archetype_successive_cells()}}.}
 
@@ -24,8 +28,6 @@ or \code{brms::brmsformula()}. Should include the full mapping
 of the model, including fixed effects, residual correlation,
 and heterogeneity in the discrete-time-specific residual variance
 components.}
-
-\item{model}{A fitted model object from \code{\link[=brm_model]{brm_model()}}.}
 
 \item{transform}{Matrix with one row per marginal mean and one column
 per model parameter. \code{\link[=brm_marginal_draws]{brm_marginal_draws()}} uses this matrix
@@ -43,6 +45,13 @@ effect size when baseline or covariates are included
 in the \code{\link[=brm_formula_sigma]{brm_formula_sigma()}} formula. If \code{effect_size} is \code{TRUE}
 in this case, then \code{\link[=brm_marginal_draws]{brm_marginal_draws()}} will automatically
 omit effect size and throw an informative warning.}
+
+\item{average_within_subgroup}{\code{TRUE}, \code{FALSE}, or \code{NULL} to control
+whether nuisance parameters are averaged within subgroup levels
+in \code{\link[=brm_transform_marginal]{brm_transform_marginal()}}. Ignored if the \code{transform} argument
+is manually supplied by the user. See the help page of
+\code{\link[=brm_transform_marginal]{brm_transform_marginal()}} for details on the
+\code{average_within_subgroup} argument.}
 
 \item{use_subgroup}{Deprecated. No longer used. \code{\link[=brm_marginal_draws]{brm_marginal_draws()}}
 no longer marginalizes over the subgroup declared

--- a/man/brm_marginal_draws_average.Rd
+++ b/man/brm_marginal_draws_average.Rd
@@ -4,13 +4,13 @@
 \alias{brm_marginal_draws_average}
 \title{Average marginal MCMC draws across time points.}
 \usage{
-brm_marginal_draws_average(data, draws, times = NULL, label = "average")
+brm_marginal_draws_average(draws, data, times = NULL, label = "average")
 }
 \arguments{
+\item{draws}{List of posterior draws from \code{\link[=brm_marginal_draws]{brm_marginal_draws()}}.}
+
 \item{data}{A classed data frame from \code{\link[=brm_data]{brm_data()}}, or an informative
 prior archetype from a function like \code{\link[=brm_archetype_successive_cells]{brm_archetype_successive_cells()}}.}
-
-\item{draws}{List of posterior draws from \code{\link[=brm_marginal_draws]{brm_marginal_draws()}}.}
 
 \item{times}{Character vector of discrete time point levels
 over which to average the MCMC samples within treatment group levels.

--- a/man/brm_model.Rd
+++ b/man/brm_model.Rd
@@ -32,7 +32,9 @@ or a \code{"brmsprior"} object from \code{brms::prior()}.}
 Must fit a continuous outcome variable and have the identity link.}
 }
 \value{
-A fitted model object from \code{brms}.
+A fitted model object from \code{brms}, with new list elements
+\code{brms.mmrm_data} and \code{brms.mmrm_formula} to capture the data
+and formula used to fit the model.
 }
 \description{
 Fit an MMRM model using \code{brms}.
@@ -93,10 +95,13 @@ tmp <- utils::capture.output(
     )
   )
 )
-# The output model is a brms model fit object.
+# The output is a brms model fit object with added list
+# elements "brms.mmrm_data" and "brms.mmrm_formula" to track the dataset
+# and formula used to fit the model.
+model$brms.mmrm_data
+model$brms.mmrm_formula
+# Otherwise, the fitted model object acts exactly like a brms fitted model.
 suppressWarnings(print(model))
-# The `prior_summary()` function shows the full prior specification
-# which reflects the fully realized fixed effects mapping.
 brms::prior_summary(model)
 }
 }

--- a/tests/testthat/test-brm_data.R
+++ b/tests/testthat/test-brm_data.R
@@ -334,6 +334,7 @@ test_that("brm_data() levels", {
       group = "nope",
       time = "col_time",
       patient = "col_patient",
+      reference_group = "group 1",
       covariates = c("col_factor2", "col_factor3")
     ),
     class = "brm_error"

--- a/tests/testthat/test-brm_marginal_draws.R
+++ b/tests/testthat/test-brm_marginal_draws.R
@@ -40,7 +40,8 @@ test_that("brm_marginal_draws() on response, no subgroup", {
     excluded <- brm_marginal_draws(
       model = model,
       formula = formula_exclude,
-      data = data
+      data = data,
+      effect_size = TRUE
     ),
     class = "brm_warn"
   )

--- a/vignettes/subgroup.Rmd
+++ b/vignettes/subgroup.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Subgroup analysis"
-bibliography: '`r system.file("bibliography.bib", package = "brms.mmrm")`'
-csl: '`r system.file("asa.csl", package = "brms.mmrm")`'
+bibliography: '/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/brms.mmrm/bibliography.bib'
+csl: '/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/brms.mmrm/asa.csl'
 output:
   rmarkdown::html_vignette:
     toc: true
@@ -38,18 +38,18 @@ raw_data <- brm_simulate_outline(
 
 raw_data
 #> # A tibble: 900 × 6
-#>    response missing group   subgroup   time   patient    
-#>       <dbl> <lgl>   <chr>   <chr>      <chr>  <chr>      
-#>  1  1.26    FALSE   group_1 subgroup_1 time_1 patient_001
-#>  2 -0.326   FALSE   group_1 subgroup_1 time_2 patient_001
-#>  3  1.33    FALSE   group_1 subgroup_1 time_3 patient_001
-#>  4  1.27    FALSE   group_1 subgroup_1 time_1 patient_002
-#>  5  0.415   FALSE   group_1 subgroup_1 time_2 patient_002
-#>  6 -1.54    FALSE   group_1 subgroup_1 time_3 patient_002
-#>  7 -0.929   FALSE   group_1 subgroup_1 time_1 patient_003
-#>  8 -0.295   FALSE   group_1 subgroup_1 time_2 patient_003
-#>  9 -0.00577 FALSE   group_1 subgroup_1 time_3 patient_003
-#> 10  2.40    FALSE   group_1 subgroup_1 time_1 patient_004
+#>    patient     time   group   subgroup   missing response
+#>    <chr>       <chr>  <chr>   <chr>      <lgl>      <dbl>
+#>  1 patient_001 time_1 group_1 subgroup_1 FALSE    1.26   
+#>  2 patient_001 time_2 group_1 subgroup_1 FALSE   -0.326  
+#>  3 patient_001 time_3 group_1 subgroup_1 FALSE    1.33   
+#>  4 patient_002 time_1 group_1 subgroup_1 FALSE    1.27   
+#>  5 patient_002 time_2 group_1 subgroup_1 FALSE    0.415  
+#>  6 patient_002 time_3 group_1 subgroup_1 FALSE   -1.54   
+#>  7 patient_003 time_1 group_1 subgroup_1 FALSE   -0.929  
+#>  8 patient_003 time_2 group_1 subgroup_1 FALSE   -0.295  
+#>  9 patient_003 time_3 group_1 subgroup_1 FALSE   -0.00577
+#> 10 patient_004 time_1 group_1 subgroup_1 FALSE    2.40   
 #> # ℹ 890 more rows
 ```
 
@@ -100,12 +100,13 @@ data <- brm_data(
 )
 
 str(data)
-#> brms_mm_ [900 × 5] (S3: brms_mmrm_data/tbl_df/tbl/data.frame)
-#>  $ response: num [1:900] 1.263 -0.326 1.33 1.272 0.415 ...
+#> brms_mm_ [900 × 6] (S3: brms_mmrm_data/tbl_df/tbl/data.frame)
+#>  $ patient : chr [1:900] "patient_001" "patient_001" "patient_001" "patient_002" ...
+#>  $ time    : chr [1:900] "time_1" "time_2" "time_3" "time_1" ...
 #>  $ group   : chr [1:900] "group_1" "group_1" "group_1" "group_1" ...
 #>  $ subgroup: chr [1:900] "subgroup_1" "subgroup_1" "subgroup_1" "subgroup_1" ...
-#>  $ time    : chr [1:900] "time_1" "time_2" "time_3" "time_1" ...
-#>  $ patient : chr [1:900] "patient_001" "patient_001" "patient_001" "patient_002" ...
+#>  $ missing : logi [1:900] FALSE FALSE FALSE FALSE FALSE FALSE ...
+#>  $ response: num [1:900] 1.263 -0.326 1.33 1.272 0.415 ...
 #>  - attr(*, "brm_outcome")= chr "response"
 #>  - attr(*, "brm_role")= chr "response"
 #>  - attr(*, "brm_group")= chr "group"
@@ -116,12 +117,6 @@ str(data)
 #>  - attr(*, "brm_reference_group")= chr "group_1"
 #>  - attr(*, "brm_reference_subgroup")= chr "subgroup_1"
 #>  - attr(*, "brm_reference_time")= chr "time_1"
-#>  - attr(*, "brm_levels_group")= chr [1:3] "group_1" "group_2" "group_3"
-#>  - attr(*, "brm_labels_group")= chr [1:3] "group_1" "group_2" "group_3"
-#>  - attr(*, "brm_levels_subgroup")= chr [1:2] "subgroup_1" "subgroup_2"
-#>  - attr(*, "brm_labels_subgroup")= chr [1:2] "subgroup_1" "subgroup_2"
-#>  - attr(*, "brm_levels_time")= chr [1:3] "time_1" "time_2" "time_3"
-#>  - attr(*, "brm_labels_time")= chr [1:3] "time_1" "time_2" "time_3"
 ```
 
 # Formula
@@ -191,28 +186,16 @@ model_reduced <- brm_model(
 
 ```r
 draws_subgroup <- brm_marginal_draws(
-  data = data,
-  formula = formula_subgroup,
   model = model_subgroup,
-  transform = brm_transform_marginal(
-    data = data,
-    formula = formula_subgroup,
-    average_within_subgroup = FALSE
-  )
+  average_within_subgroup = FALSE
 )
 ```
 
 
 ```r
 draws_reduced <- brm_marginal_draws(
-  data = data,
-  formula = formula_reduced,
   model = model_reduced,
-  transform = brm_transform_marginal(
-    data = data,
-    formula = formula_reduced,
-    average_within_subgroup = FALSE
-  )
+  average_within_subgroup = FALSE
 )
 ```
 
@@ -281,7 +264,7 @@ summaries_reduced <- brm_marginal_summaries(
 )
 
 summaries_subgroup
-#> # A tibble: 250 × 7
+#> # A tibble: 340 × 7
 #>    marginal         statistic group   subgroup   time     value    mcse
 #>    <chr>            <chr>     <chr>   <chr>      <chr>    <dbl>   <dbl>
 #>  1 difference_group lower     group_2 subgroup_1 time_2 -0.300  0.00952
@@ -294,7 +277,7 @@ summaries_subgroup
 #>  8 difference_group lower     group_3 subgroup_2 time_3 -0.286  0.00976
 #>  9 difference_group mean      group_2 subgroup_1 time_2  0.0913 0.00439
 #> 10 difference_group mean      group_2 subgroup_1 time_3 -0.167  0.00403
-#> # ℹ 240 more rows
+#> # ℹ 330 more rows
 ```
 
 `brm_marginal_probabilities()` still focuses on treatment effects, not on differences between pairs of subgroup levels.
@@ -468,7 +451,7 @@ loo::loo_compare(loo_subgroup, loo_reduced)
 brm_plot_draws(draws_subgroup$difference_group)
 ```
 
-![plot of chunk draws](subgroup/draws-1.png)
+![](subgroup/draws-1.png)
 
 You can adjust visual aesthetics to compare subgroup levels side by side if subgroup level is the primary comparison of interest.
 
@@ -481,7 +464,7 @@ brm_plot_draws(
 )
 ```
 
-![plot of chunk drawscustom](subgroup/drawscustom-1.png)
+![](subgroup/drawscustom-1.png)
 
 The following function call compares the subgroup model results against the subgroup data.
 
@@ -494,7 +477,7 @@ brm_plot_compare(
 )
 ```
 
-![plot of chunk subgroup-vs-data](subgroup/subgroup-vs-data-1.png)
+![](subgroup/subgroup-vs-data-1.png)
 
 You can adjust plot aesthetics to view subgroup levels side by side as the primary comparison of interest.
 
@@ -510,7 +493,7 @@ brm_plot_compare(
 )
 ```
 
-![plot of chunk subgroup-vs-data-levels](subgroup/subgroup-vs-data-levels-1.png)
+![](subgroup/subgroup-vs-data-levels-1.png)
 
 We can also visually compare the treatment effects of a subgroup level against the marginal treatment effects of the reduced model.
 
@@ -523,7 +506,7 @@ brm_plot_compare(
 )
 ```
 
-![plot of chunk reduced-model-comparison](subgroup/reduced-model-comparison-1.png)
+![](subgroup/reduced-model-comparison-1.png)
 
 Please remember to filter on a single subgroup level. Otherwise, `brm_plot_compare()` throws an informative error to prevent overplotting.
 

--- a/vignettes/subgroup.Rmd
+++ b/vignettes/subgroup.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Subgroup analysis"
-bibliography: '/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/brms.mmrm/bibliography.bib'
-csl: '/Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/brms.mmrm/asa.csl'
+bibliography: '`r system.file("bibliography.bib", package = "brms.mmrm")`'
+csl: '`r system.file("asa.csl", package = "brms.mmrm")`'
 output:
   rmarkdown::html_vignette:
     toc: true

--- a/vignettes/subgroup.Rmd.source
+++ b/vignettes/subgroup.Rmd.source
@@ -130,27 +130,15 @@ model_reduced <- brm_model(
 
 ```{r}
 draws_subgroup <- brm_marginal_draws(
-  data = data,
-  formula = formula_subgroup,
   model = model_subgroup,
-  transform = brm_transform_marginal(
-    data = data,
-    formula = formula_subgroup,
-    average_within_subgroup = FALSE
-  )
+  average_within_subgroup = FALSE
 )
 ```
 
 ```{r}
 draws_reduced <- brm_marginal_draws(
-  data = data,
-  formula = formula_reduced,
   model = model_reduced,
-  transform = brm_transform_marginal(
-    data = data,
-    formula = formula_reduced,
-    average_within_subgroup = FALSE
-  )
+  average_within_subgroup = FALSE
 )
 ```
 

--- a/vignettes/usage.Rmd
+++ b/vignettes/usage.Rmd
@@ -49,7 +49,8 @@ raw_data
 #> # ℹ 1,190 more rows
 ```
 
-It is good practice to call `brm_data_chronologize()` to convert the time variable to an ordered factor so individual discrete time points correctly represent correct chronological order.^[`brm_data_chronologize()` also has the added benefit of applying `contr.treatment()` post-hoc to avoid [counterintuitive polynomial contrasts for ordered factors](https://library.virginia.edu/data/articles/understanding-ordered-factors-in-a-linear-model). That way, the fixed effect parameterizations in the model conform to our expectations about factors.]
+It is good practice to convert the time variable to an ordered factor so individual discrete time points correctly represent correct chronological order.^[Ordered factors usually have polynomial contrasts (`contr.poly()`), which makes the fixed effect parameterization counterintuitive. However, `brm_data()` manually sets the contrasts of the time variable to be treatment contrasts (`contr.treatment()`) so there are individual fixed effects for individual discrete time points. To revert back to polynomial contrasts, use `contr.poly()` after the call to `brm_data()`.]
+
 
 ```r
 raw_data <- raw_data |>
@@ -294,7 +295,7 @@ model <- brm_model(data = data, formula = formula, refresh = 0)
 
 
 
-The result is a `brms` model object.
+The result is a `brms` model object with extra list elements `brms.mmrm_data` and `brms.mmrm_formula` to keep track of the data and formula used to fit the model.
 
 
 ```r
@@ -349,6 +350,32 @@ model
 #> scale reduction factor on split chains (at convergence, Rhat = 1).
 ```
 
+
+```r
+model$brms.mmrm_data
+#> # A tibble: 1,200 × 7
+#>    patient     time   response group   biomarker1 biomarker2 biomarker3
+#>    <chr>       <ord>     <dbl> <chr>        <dbl>      <dbl>      <dbl>
+#>  1 patient_001 time_1    1.11  group_1      1.31      -0.361      1.52 
+#>  2 patient_001 time_2    2.15  group_1      1.31      -0.361      1.52 
+#>  3 patient_001 time_3    2.54  group_1      1.31      -0.361      1.52 
+#>  4 patient_001 time_4   -1.73  group_1      1.31      -0.361      1.52 
+#>  5 patient_002 time_1    1.11  group_1      0.107     -2.44      -0.139
+#>  6 patient_002 time_2    2.64  group_1      0.107     -2.44      -0.139
+#>  7 patient_002 time_3    1.69  group_1      0.107     -2.44      -0.139
+#>  8 patient_002 time_4    0.783 group_1      0.107     -2.44      -0.139
+#>  9 patient_003 time_1    0.118 group_1      1.44      -0.419     -1.54 
+#> 10 patient_003 time_2    2.48  group_1      1.44      -0.419     -1.54 
+#> # ℹ 1,190 more rows
+```
+
+
+```r
+model$brms.mmrm_formula
+#> response ~ group + group:time + time + biomarker1 + biomarker2 + unstr(time = time, gr = patient) 
+#> sigma ~ 0 + time
+```
+
 # Marginals
 
 Regardless of the choice of fixed effects formula, `brms.mmrm` performs inference on the marginal distributions at each treatment group and time point of the mean of the following quantities:
@@ -362,7 +389,7 @@ To derive posterior draws of these marginals, use the `brm_marginal_draws()` fun
 
 
 ```r
-draws <- brm_marginal_draws(data = data, formula = formula, model = model)
+draws <- brm_marginal_draws(model = model)
 
 draws
 #> $response
@@ -678,7 +705,7 @@ brm_plot_compare(
 )
 ```
 
-![plot of chunk response](usage/response-1.png)
+![](usage/response-1.png)
 
 If you omit the marginals of the data, you can show inference on change from baseline or the treatment effect.
 
@@ -691,7 +718,7 @@ brm_plot_compare(
 )
 ```
 
-![plot of chunk difference](usage/difference-1.png)
+![](usage/difference-1.png)
 
 Additional arguments let you control the primary comparison of interest (the color aesthetic), the horizontal axis, and the faceting variable.
 
@@ -707,7 +734,7 @@ brm_plot_compare(
 )
 ```
 
-![plot of chunk differencecustom](usage/differencecustom-1.png)
+![](usage/differencecustom-1.png)
 
 Finally, `brm_plot_draws()` can plot the posterior draws of the response, change from baseline, or treatment difference.
 
@@ -716,7 +743,7 @@ Finally, `brm_plot_draws()` can plot the posterior draws of the response, change
 brm_plot_draws(draws = draws$difference_group)
 ```
 
-![plot of chunk draws](usage/draws-1.png)
+![](usage/draws-1.png)
 
 The `axis` and `facet` arguments customize the horizontal axis and faceting variable, respectively.
 
@@ -729,4 +756,4 @@ brm_plot_draws(
 )
 ```
 
-![plot of chunk drawscustom](usage/drawscustom-1.png)
+![](usage/drawscustom-1.png)

--- a/vignettes/usage.Rmd.source
+++ b/vignettes/usage.Rmd.source
@@ -164,10 +164,18 @@ model <- brm_model(data = data, formula = formula, refresh = 0)
 model <- brm_model(data = data, formula = formula, refresh = 0)
 ```
 
-The result is a `brms` model object.
+The result is a `brms` model object with extra list elements `brms.mmrm_data` and `brms.mmrm_formula` to keep track of the data and formula used to fit the model.
 
 ```{r}
 model
+```
+
+```{r}
+model$brms.mmrm_data
+```
+
+```{r}
+model$brms.mmrm_formula
 ```
 
 # Marginals
@@ -182,7 +190,7 @@ Regardless of the choice of fixed effects formula, `brms.mmrm` performs inferenc
 To derive posterior draws of these marginals, use the `brm_marginal_draws()` function.
 
 ```{r, paged.print = FALSE}
-draws <- brm_marginal_draws(data = data, formula = formula, model = model)
+draws <- brm_marginal_draws(model = model)
 
 draws
 ```


### PR DESCRIPTION
This PR implements interface improvements based on suggestions by Björn Holzhauer:

* Add new elements `brms.mmrm_data` and `brms.mmrm_formula` to the `brms` fitted model object returned by `brm_model()`.
* Take defaults `data` and `formula` from the above in `brm_marginal_draws()` so only the model needs to be directly specified in most cases.
* Set the default value of `effect_size` to `attr(formula, "brm_allow_effect_size")`.
* Use documentation rather than default arguments to suggest input values to `brm_data()`.